### PR TITLE
Wire in additional PG Gate APIs and clean up

### DIFF
--- a/src/gausskernel/storage/access/k2/pg_gate_api.cpp
+++ b/src/gausskernel/storage/access/k2/pg_gate_api.cpp
@@ -787,23 +787,22 @@ K2PgStatus PgGate_OperatorAppendArg(K2PgExpr op_handle, K2PgExpr arg){
 // Referential Integrity Check Caching.
 // Check if foreign key reference exists in cache.
 bool PgGate_ForeignKeyReferenceExists(K2PgOid table_oid, const char* k2pgctid, int64_t k2pgctid_size) {
-    elog(DEBUG5, "PgGateAPI: PgGate_ForeignKeyReferenceExists %d, %s, %ld", table_oid, k2pgctid, k2pgctid_size);
+    elog(DEBUG5, "PgGateAPI: PgGate_ForeignKeyReferenceExists %d, %p, %ld", table_oid, k2pgctid, k2pgctid_size);
     return k2pg::pg_session->ForeignKeyReferenceExists(table_oid, std::string(k2pgctid, k2pgctid_size));
 }
 
 // Add an entry to foreign key reference cache.
 K2PgStatus PgGate_CacheForeignKeyReference(K2PgOid table_oid, const char* k2pgctid, int64_t k2pgctid_size){
-    elog(DEBUG5, "PgGateAPI: PgGate_CacheForeignKeyReference %d, %s, %ld", table_oid, k2pgctid, k2pgctid_size);
+    elog(DEBUG5, "PgGateAPI: PgGate_CacheForeignKeyReference %d, %p, %ld", table_oid, k2pgctid, k2pgctid_size);
     return k2pg::pg_session->CacheForeignKeyReference(table_oid, std::string(k2pgctid, k2pgctid_size));
 }
 
 // Delete an entry from foreign key reference cache.
 K2PgStatus PgGate_DeleteFromForeignKeyReferenceCache(K2PgOid table_oid, uint64_t k2pgctid){
     elog(DEBUG5, "PgGateAPI: PgGate_DeleteFromForeignKeyReferenceCache %d, %lu", table_oid, k2pgctid);
-    char *value;
-    int64_t bytes;
-    const K2PgTypeEntity *type_entity = pg_gate->FindTypeEntity(k2pg::kPgByteArrayOid);
-    type_entity->datum_to_k2pg(k2pgctid, &value, &bytes);
+    k2pg::UntoastedDatum data = k2pg::UntoastedDatum(k2pgctid);
+    int64_t bytes = VARSIZE(data.untoasted); // includes header len VARHDRSZ
+    char *value = (char*)data.untoasted;
     return k2pg::pg_session->DeleteForeignKeyReference(table_oid, std::string(value, bytes));
 }
 

--- a/src/gausskernel/storage/access/k2/pg_gate_api.cpp
+++ b/src/gausskernel/storage/access/k2/pg_gate_api.cpp
@@ -464,87 +464,9 @@ K2PgStatus PgGate_ExecDropIndex(K2PgStatement handle){
   return K2PgStatus::NotSupported;
 }
 
-K2PgStatus PgGate_WaitUntilIndexPermissionsAtLeast(
-    const K2PgOid database_oid,
-    const K2PgOid table_oid,
-    const K2PgOid index_oid,
-    const uint32_t target_index_permissions,
-    uint32_t *actual_index_permissions) {
-  elog(DEBUG5, "PgGateAPI: PgGate_WaitUntilIndexPermissionsAtLeast %d, %d, %d", database_oid, table_oid, index_oid);
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_AsyncUpdateIndexPermissions(
-    const K2PgOid database_oid,
-    const K2PgOid indexed_table_oid){
-  elog(DEBUG5, "PgGateAPI: PgGate_AsyncUpdateIndexPermissions %d, %d", database_oid,  indexed_table_oid);
-  return K2PgStatus::NotSupported;
-}
-
 //--------------------------------------------------------------------------------------------------
 // DML statements (select, insert, update, delete, truncate)
 //--------------------------------------------------------------------------------------------------
-
-// This function is for specifying the selected or returned expressions.
-// - SELECT target_expr1, target_expr2, ...
-// - INSERT / UPDATE / DELETE ... RETURNING target_expr1, target_expr2, ...
-K2PgStatus PgGate_DmlAppendTarget(K2PgStatement handle, K2PgExpr target){
-  elog(DEBUG5, "PgGateAPI: PgGate_DmlAppendTarget");
-  return K2PgStatus::NotSupported;
-}
-
-// Binding Columns: Bind column with a value (expression) in a statement.
-// + This API is used to identify the rows you want to operate on. If binding columns are not
-//   there, that means you want to operate on all rows (full scan). You can view this as a
-//   a definitions of an initial rowset or an optimization over full-scan.
-//
-// + There are some restrictions on when BindColumn() can be used.
-//   Case 1: INSERT INTO tab(x) VALUES(x_expr)
-//   - BindColumn() can be used for BOTH primary-key and regular columns.
-//   - This bind-column function is used to bind "x" with "x_expr", and "x_expr" that can contain
-//     bind-variables (placeholders) and constants whose values can be updated for each execution
-//     of the same allocated statement.
-//
-//   Case 2: SELECT / UPDATE / DELETE <WHERE key = "key_expr">
-//   - BindColumn() can only be used for primary-key columns.
-//   - This bind-column function is used to bind the primary column "key" with "key_expr" that can
-//     contain bind-variables (placeholders) and constants whose values can be updated for each
-//     execution of the same allocated statement.
-//
-// NOTE ON KEY BINDING
-// - For Sequential Scan, the target columns of the bind are those in the main table.
-// - For Primary Scan, the target columns of the bind are those in the main table.
-// - For Index Scan, the target columns of the bind are those in the index table.
-//   The index-scan will use the bind to find base-k2pgctid which is then use to read data from
-//   the main-table, and therefore the bind-arguments are not associated with columns in main table.
-K2PgStatus PgGate_DmlBindColumn(K2PgStatement handle, int attr_num, K2PgExpr attr_value){
-  elog(DEBUG5, "PgGateAPI: PgGate_DmlBindColumn %d", attr_num);
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_DmlBindRangeConds(K2PgStatement handle, K2PgExpr range_conds) {
-  elog(DEBUG5, "PgGateAPI: PgGate_DmlBindRangeConds");
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_DmlBindWhereConds(K2PgStatement handle, K2PgExpr where_conds) {
-  elog(DEBUG5, "PgGateAPI: PgGate_DmlBindWhereConds");
-  return K2PgStatus::NotSupported;
-}
-
-// Binding Tables: Bind the whole table in a statement.  Do not use with BindColumn.
-K2PgStatus PgGate_DmlBindTable(K2PgStatement handle){
-  elog(DEBUG5, "PgGateAPI: PgGate_DmlBindTable");
-  return K2PgStatus::NotSupported;
-}
-
-// API for SET clause.
-K2PgStatus PgGate_DmlAssignColumn(K2PgStatement handle,
-                               int attr_num,
-                               K2PgExpr attr_value){
-  elog(DEBUG5, "PgGateAPI: PgGate_DmlAssignColumn %d", attr_num);
-  return K2PgStatus::NotSupported;
-}
 
 // This function is to fetch the targets in PgGate_DmlAppendTarget() from the rows that were defined
 // by PgGate_DmlBindColumn().
@@ -849,43 +771,6 @@ K2PgStatus PgGate_NewConstantOp(K2PgStatement stmt, const K2PgTypeEntity *type_e
   return K2PgStatus::NotSupported;
 }
 
-// The following update functions only work for constants.
-// Overwriting the constant expression with new value.
-K2PgStatus PgGate_UpdateConstInt2(K2PgExpr expr, int16_t value, bool is_null){
-  elog(DEBUG5, "PgGateAPI: PgGate_UpdateConstInt2 %d, %d", value, is_null);
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_UpdateConstInt4(K2PgExpr expr, int32_t value, bool is_null){
-  elog(DEBUG5, "PgGateAPI: PgGate_UpdateConstInt4 %d, %d", value, is_null);
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_UpdateConstInt8(K2PgExpr expr, int64_t value, bool is_null){
-  elog(DEBUG5, "PgGateAPI: PgGate_UpdateConstInt8 %ld, %d", value, is_null);
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_UpdateConstFloat4(K2PgExpr expr, float value, bool is_null){
-  elog(DEBUG5, "PgGateAPI: PgGate_UpdateConstFloat4 %f, %d", value, is_null);
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_UpdateConstFloat8(K2PgExpr expr, double value, bool is_null){
-  elog(DEBUG5, "PgGateAPI: PgGate_UpdateConstFloat8 %f, %d", value, is_null);
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_UpdateConstText(K2PgExpr expr, const char *value, bool is_null){
-  elog(DEBUG5, "PgGateAPI: PgGate_UpdateConstText %s, %d", value, is_null);
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_UpdateConstChar(K2PgExpr expr, const char *value, int64_t bytes, bool is_null){
-  elog(DEBUG5, "PgGateAPI: PgGate_UpdateConstChar %s, %ld, %d", value, bytes, is_null);
-  return K2PgStatus::NotSupported;
-}
-
 // Expressions with operators "=", "+", "between", "in", ...
 K2PgStatus PgGate_NewOperator(K2PgStatement stmt, const char *opname,
                            const K2PgTypeEntity *type_entity,
@@ -925,34 +810,6 @@ K2PgStatus PgGate_DeleteFromForeignKeyReferenceCache(K2PgOid table_oid, uint64_t
 void PgGate_ClearForeignKeyReferenceCache() {
     elog(DEBUG5, "PgGateAPI: PgGate_ClearForeignKeyReferenceCache");
     k2pg::pg_session->InvalidateForeignKeyReferenceCache();
-}
-
-bool PgGate_IsInitDbModeEnvVarSet() {
-  elog(DEBUG5, "PgGateAPI: PgGate_IsInitDbModeEnvVarSet");
-  return false;
-}
-
-// This is called by initdb. Used to customize some behavior.
-void PgGate_InitFlags() {
-  elog(DEBUG5, "PgGateAPI: PgGate_InitFlags");
-}
-
-// Retrieves value of psql_max_read_restart_attempts gflag
-int32_t PgGate_GetMaxReadRestartAttempts() {
-  elog(DEBUG5, "PgGateAPI: PgGate_GetMaxReadRestartAttempts");
-  return default_max_read_restart_attempts;
-}
-
-// Retrieves value of psql_output_buffer_size gflag
-int32_t PgGate_GetOutputBufferSize() {
-  elog(DEBUG5, "PgGateAPI: PgGate_GetOutputBufferSize");
-  return default_output_buffer_size;
-}
-
-// Retrieve value of psql_disable_index_backfill gflag.
-bool PgGate_GetDisableIndexBackfill() {
-  elog(DEBUG5, "PgGateAPI: PgGate_GetDisableIndexBackfill");
-  return default_disable_index_backfill;
 }
 
 bool PgGate_IsK2PgEnabled() {

--- a/src/gausskernel/storage/access/k2/pg_gate_api.cpp
+++ b/src/gausskernel/storage/access/k2/pg_gate_api.cpp
@@ -400,32 +400,30 @@ K2PgStatus PgGate_ExecDropTable(K2PgStatement handle){
 K2PgStatus PgGate_GetTableDesc(K2PgOid database_oid,
                             K2PgOid table_oid,
                             K2PgTableDesc *handle) {
-  elog(DEBUG5, "PgGateAPI: PgGate_GetTableDesc %d, %d", database_oid, table_oid);
-  return K2PgStatus::NotSupported;
+    elog(DEBUG5, "PgGateAPI: PgGate_GetTableDesc %d, %d", database_oid, table_oid);
+    *handle = k2pg::pg_session->LoadTable(database_oid, table_oid).get();
+    return K2PgStatus::OK;
 }
 
 K2PgStatus PgGate_GetColumnInfo(K2PgTableDesc table_desc,
                              int16_t attr_number,
                              bool *is_primary,
                              bool *is_hash) {
-  elog(DEBUG5, "PgGateAPI: PgGate_GetTableDesc %d", attr_number);
-  return K2PgStatus::NotSupported;
-}
-
-K2PgStatus PgGate_GetTableProperties(K2PgTableDesc table_desc,
-                                  K2PgTableProperties *properties){
-  elog(DEBUG5, "PgGateAPI: PgGate_GetTableProperties");
-  return K2PgStatus::NotSupported;
+    elog(DEBUG5, "PgGateAPI: PgGate_GetTableDesc %d", attr_number);
+    return table_desc->GetColumnInfo(attr_number, is_primary, is_hash);
 }
 
 K2PgStatus PgGate_SetIsSysCatalogVersionChange(K2PgStatement handle){
-  elog(DEBUG5, "PgGateAPI: PgGate_SetIsSysCatalogVersionChange");
-  return K2PgStatus::NotSupported;
+    elog(DEBUG5, "PgGateAPI: PgGate_SetIsSysCatalogVersionChange");
+    // TODO: check if we don't need this
+    handle->SetSysCatalogVersionChange();
+    return pg_gate->GetCatalogClient()->IncrementCatalogVersion();
 }
 
 K2PgStatus PgGate_SetCatalogCacheVersion(K2PgStatement handle, uint64_t catalog_cache_version){
-  elog(DEBUG5, "PgGateAPI: PgGate_SetCatalogCacheVersion %ld", catalog_cache_version);
-  return K2PgStatus::NotSupported;
+    elog(DEBUG5, "PgGateAPI: PgGate_SetCatalogCacheVersion %ld", catalog_cache_version);
+    handle->SetCatalogCacheVersion(catalog_cache_version);
+    return K2PgStatus::OK;
 }
 
 // INDEX -------------------------------------------------------------------------------------------

--- a/src/gausskernel/storage/access/k2/pg_gate_api.cpp
+++ b/src/gausskernel/storage/access/k2/pg_gate_api.cpp
@@ -902,24 +902,29 @@ K2PgStatus PgGate_OperatorAppendArg(K2PgExpr op_handle, K2PgExpr arg){
 // Referential Integrity Check Caching.
 // Check if foreign key reference exists in cache.
 bool PgGate_ForeignKeyReferenceExists(K2PgOid table_oid, const char* k2pgctid, int64_t k2pgctid_size) {
-  elog(DEBUG5, "PgGateAPI: PgGate_ForeignKeyReferenceExists %d, %s, %ld", table_oid, k2pgctid, k2pgctid_size);
-  return false;
+    elog(DEBUG5, "PgGateAPI: PgGate_ForeignKeyReferenceExists %d, %s, %ld", table_oid, k2pgctid, k2pgctid_size);
+    return k2pg::pg_session->ForeignKeyReferenceExists(table_oid, std::string(k2pgctid, k2pgctid_size));
 }
 
 // Add an entry to foreign key reference cache.
 K2PgStatus PgGate_CacheForeignKeyReference(K2PgOid table_oid, const char* k2pgctid, int64_t k2pgctid_size){
-  elog(DEBUG5, "PgGateAPI: PgGate_CacheForeignKeyReference %d, %s, %ld", table_oid, k2pgctid, k2pgctid_size);
-  return K2PgStatus::NotSupported;
+    elog(DEBUG5, "PgGateAPI: PgGate_CacheForeignKeyReference %d, %s, %ld", table_oid, k2pgctid, k2pgctid_size);
+    return k2pg::pg_session->CacheForeignKeyReference(table_oid, std::string(k2pgctid, k2pgctid_size));
 }
 
 // Delete an entry from foreign key reference cache.
 K2PgStatus PgGate_DeleteFromForeignKeyReferenceCache(K2PgOid table_oid, uint64_t k2pgctid){
-  elog(DEBUG5, "PgGateAPI: PgGate_DeleteFromForeignKeyReferenceCache %d, %lu", table_oid, k2pgctid);
-  return K2PgStatus::NotSupported;
+    elog(DEBUG5, "PgGateAPI: PgGate_DeleteFromForeignKeyReferenceCache %d, %lu", table_oid, k2pgctid);
+    char *value;
+    int64_t bytes;
+    const K2PgTypeEntity *type_entity = pg_gate->FindTypeEntity(k2pg::kPgByteArrayOid);
+    type_entity->datum_to_k2pg(k2pgctid, &value, &bytes);
+    return k2pg::pg_session->DeleteForeignKeyReference(table_oid, std::string(value, bytes));
 }
 
 void PgGate_ClearForeignKeyReferenceCache() {
-  elog(DEBUG5, "PgGateAPI: PgGate_ClearForeignKeyReferenceCache");
+    elog(DEBUG5, "PgGateAPI: PgGate_ClearForeignKeyReferenceCache");
+    k2pg::pg_session->InvalidateForeignKeyReferenceCache();
 }
 
 bool PgGate_IsInitDbModeEnvVarSet() {

--- a/src/gausskernel/storage/access/k2/pg_session.cpp
+++ b/src/gausskernel/storage/access/k2/pg_session.cpp
@@ -91,4 +91,33 @@ std::shared_ptr<PgTableDesc> PgSession::LoadTable(const PgObjectId& table_object
     }
 }
 
+bool operator==(const PgForeignKeyReference& k1, const PgForeignKeyReference& k2) {
+  return k1.table_oid == k2.table_oid &&
+      k1.k2pgctid == k2.k2pgctid;
+}
+
+size_t hash_value(const PgForeignKeyReference& key) {
+  size_t hash = 0;
+  boost::hash_combine(hash, key.table_oid);
+  boost::hash_combine(hash, key.k2pgctid);
+  return hash;
+}
+
+bool PgSession::ForeignKeyReferenceExists(uint32_t table_oid, std::string&& k2pgctid) {
+  PgForeignKeyReference reference{table_oid, std::move(k2pgctid)};
+  return fk_reference_cache_.find(reference) != fk_reference_cache_.end();
+}
+
+Status PgSession::CacheForeignKeyReference(uint32_t table_oid, std::string&& k2pgctid) {
+  PgForeignKeyReference reference{table_oid, std::move(k2pgctid)};
+  fk_reference_cache_.emplace(reference);
+  return Status::OK;
+}
+
+Status PgSession::DeleteForeignKeyReference(uint32_t table_oid, std::string&& k2pgctid) {
+  PgForeignKeyReference reference{table_oid, std::move(k2pgctid)};
+  fk_reference_cache_.erase(reference);
+  return Status::OK;
+}
+
 }  // namespace k2pg

--- a/src/gausskernel/storage/access/k2/pg_statement.cpp
+++ b/src/gausskernel/storage/access/k2/pg_statement.cpp
@@ -26,9 +26,9 @@ Copyright(c) 2022 Futurewei Cloud
 namespace k2pg {
 
 PgStatement::PgStatement(std::shared_ptr<PgSession> pg_session) :
-  pg_session_(pg_session),
-  client_id_(pg_session_->GetClientId()),
-  stmt_id_(pg_session_->GetNextStmtId()) {
+    pg_session_(pg_session),
+    client_id_(pg_session_->GetClientId()),
+    stmt_id_(pg_session_->GetNextStmtId()) {
 }
 
 PgStatement::~PgStatement() {

--- a/src/gausskernel/storage/k2/fdw_handlers.cpp
+++ b/src/gausskernel/storage/k2/fdw_handlers.cpp
@@ -514,10 +514,6 @@ static void BindScanKeys(Relation relation,
         }
     }
 
-    //HandleK2PgStatusWithOwner(PgGate_DmlBindRangeConds(fdw_state->handle, range_conds),
-    //                                                    fdw_state->handle,
-    //                                                    fdw_state->stmt_owner);
-
     Expression where_conds{};
     // Top level should be an "AND" node
     where_conds.op = Operation::AND;
@@ -541,9 +537,6 @@ static void BindScanKeys(Relation relation,
         }
     }
 
-    //HandleK2PgStatusWithOwner(PgGate_DmlBindWhereConds(fdw_state->handle, where_conds),
-    //                                                    fdw_state->handle,
-    //                                                    fdw_state->stmt_owner);
     scan_plan->range_conds = std::move(range_conds);
     scan_plan->where_conds = std::move(where_conds);
 }

--- a/src/include/access/k2/pg_gate_api.h
+++ b/src/include/access/k2/pg_gate_api.h
@@ -161,9 +161,6 @@ K2PgStatus PgGate_GetColumnInfo(K2PgTableDesc table_desc,
                              bool *is_primary,
                              bool *is_hash);
 
-K2PgStatus PgGate_GetTableProperties(K2PgTableDesc table_desc,
-                                  K2PgTableProperties *properties);
-
 K2PgStatus PgGate_SetIsSysCatalogVersionChange(K2PgStatement handle);
 
 K2PgStatus PgGate_SetCatalogCacheVersion(K2PgStatement handle, uint64_t catalog_cache_version);

--- a/src/include/access/k2/pg_gate_api.h
+++ b/src/include/access/k2/pg_gate_api.h
@@ -187,17 +187,6 @@ K2PgStatus PgGate_NewDropIndex(K2PgOid database_oid,
 
 K2PgStatus PgGate_ExecDropIndex(K2PgStatement handle);
 
-K2PgStatus PgGate_WaitUntilIndexPermissionsAtLeast(
-    const K2PgOid database_oid,
-    const K2PgOid table_oid,
-    const K2PgOid index_oid,
-    const uint32_t target_index_permissions,
-    uint32_t *actual_index_permissions);
-
-K2PgStatus PgGate_AsyncUpdateIndexPermissions(
-    const K2PgOid database_oid,
-    const K2PgOid indexed_table_oid);
-
 //--------------------------------------------------------------------------------------------------
 // DML statements (select, insert, update, delete, truncate)
 //--------------------------------------------------------------------------------------------------
@@ -227,17 +216,6 @@ struct K2PgAttributeDef {
 };
 
 class K2PgScanHandle;
-
-// bind range condition so as to derive key prefix
-// TODO maybe remove if not needed after user table scan is hooked in
-K2PgStatus PgGate_DmlBindRangeConds(K2PgStatement handle, K2PgExpr where_conds);
-
-// bind where clause for a DML operation
-// TODO maybe remove if not needed after user table scan is hooked in
-K2PgStatus PgGate_DmlBindWhereConds(K2PgStatement handle, K2PgExpr where_conds);
-
-// Binding Tables: Bind the whole table in a statement.  Do not use with BindColumn.
-K2PgStatus PgGate_DmlBindTable(K2PgStatement handle);
 
 // This function is to fetch the targets in the vector from the Exec call, from the rows that were defined
 // by the constraints vector in the Exec call
@@ -356,16 +334,6 @@ K2PgStatus PgGate_NewConstant(K2PgStatement stmt, const K2PgTypeEntity *type_ent
 K2PgStatus PgGate_NewConstantOp(K2PgStatement stmt, const K2PgTypeEntity *type_entity,
                            uint64_t datum, bool is_null, K2PgExpr *expr_handle, bool is_gt);
 
-// The following update functions only work for constants.
-// Overwriting the constant expression with new value.
-K2PgStatus PgGate_UpdateConstInt2(K2PgExpr expr, int16_t value, bool is_null);
-K2PgStatus PgGate_UpdateConstInt4(K2PgExpr expr, int32_t value, bool is_null);
-K2PgStatus PgGate_UpdateConstInt8(K2PgExpr expr, int64_t value, bool is_null);
-K2PgStatus PgGate_UpdateConstFloat4(K2PgExpr expr, float value, bool is_null);
-K2PgStatus PgGate_UpdateConstFloat8(K2PgExpr expr, double value, bool is_null);
-K2PgStatus PgGate_UpdateConstText(K2PgExpr expr, const char *value, bool is_null);
-K2PgStatus PgGate_UpdateConstChar(K2PgExpr expr, const char *value, int64_t bytes, bool is_null);
-
 // Expressions with operators "=", "+", "between", "in", ...
 K2PgStatus PgGate_NewOperator(K2PgStatement stmt, const char *opname,
                            const K2PgTypeEntity *type_entity,
@@ -383,20 +351,6 @@ K2PgStatus PgGate_CacheForeignKeyReference(K2PgOid table_oid, const char* k2pgct
 K2PgStatus PgGate_DeleteFromForeignKeyReferenceCache(K2PgOid table_oid, uint64_t k2pgctid);
 
 void PgGate_ClearForeignKeyReferenceCache();
-
-bool PgGate_IsInitDbModeEnvVarSet();
-
-// This is called by initdb. Used to customize some behavior.
-void PgGate_InitFlags();
-
-// Retrieves value of psql_max_read_restart_attempts gflag
-int32_t PgGate_GetMaxReadRestartAttempts();
-
-// Retrieves value of psql_output_buffer_size gflag
-int32_t PgGate_GetOutputBufferSize();
-
-// Retrieve value of psql_disable_index_backfill gflag.
-bool PgGate_GetDisableIndexBackfill();
 
 bool PgGate_IsK2PgEnabled();
 

--- a/src/include/access/k2/pg_statement.h
+++ b/src/include/access/k2/pg_statement.h
@@ -52,38 +52,50 @@ enum StmtOp {
 };
 
 class PgStatement {
- public:
+  public:
 
-  //------------------------------------------------------------------------------------------------
-  // Constructors.
-  // pg_session is the session that this statement belongs to. If PostgreSQL cancels the session
-  // while statement is running, pg_session::sharedptr can still be accessed without crashing.
-  explicit PgStatement(std::shared_ptr<PgSession> pg_session);
-  virtual ~PgStatement();
+    //------------------------------------------------------------------------------------------------
+    // Constructors.
+    // pg_session is the session that this statement belongs to. If PostgreSQL cancels the session
+    // while statement is running, pg_session::sharedptr can still be accessed without crashing.
+    explicit PgStatement(std::shared_ptr<PgSession> pg_session);
+    virtual ~PgStatement();
 
-  const std::shared_ptr<PgSession>& pg_session() {
-    return pg_session_;
-  }
+    const std::shared_ptr<PgSession>& pg_session() {
+        return pg_session_;
+    }
 
-  // Statement type.
-  virtual StmtOp stmt_op() const = 0;
+    // Statement type.
+    virtual StmtOp stmt_op() const = 0;
 
-  //------------------------------------------------------------------------------------------------
-  static bool IsValidStmt(PgStatement* stmt, StmtOp op) {
-    return (stmt != nullptr && stmt->stmt_op() == op);
-  }
+    //------------------------------------------------------------------------------------------------
+    static bool IsValidStmt(PgStatement* stmt, StmtOp op) {
+        return (stmt != nullptr && stmt->stmt_op() == op);
+    }
 
-  int64_t stmt_id() const {
-    return stmt_id_;
-  }
+    int64_t stmt_id() const {
+        return stmt_id_;
+    }
 
- protected:
-  // PgSession that this statement belongs to.
-  std::shared_ptr<PgSession> pg_session_;
+    void SetCatalogCacheVersion(uint64_t catalog_cache_version) {
+        catalog_cache_version_ = catalog_cache_version;
+    }
 
-  std::string client_id_;
+    void SetSysCatalogVersionChange() {
+        catalog_version_change_ = true;
+    }
 
-  int64_t stmt_id_;
+    protected:
+    // PgSession that this statement belongs to.
+    std::shared_ptr<PgSession> pg_session_;
+
+    std::string client_id_;
+
+    int64_t stmt_id_;
+
+    uint64_t catalog_cache_version_ = 0;
+
+    bool catalog_version_change_ = false;
 };
 
 }  // namespace k2pg


### PR DESCRIPTION
1) wire in PgGate_GetTableDesc, PgGate_GetColumnInfo, PgGate_SetIsSysCatalogVersionChange, and PgGate_SetCatalogCacheVersion
2)  add foreign key constraint logic
3)  remove unneeded pg_gate apis