### PR TITLE
add logic to populate kPgRowId column if it is not specified

### DIFF
--- a/src/gausskernel/storage/access/k2/pg_gate_api.cpp
+++ b/src/gausskernel/storage/access/k2/pg_gate_api.cpp
@@ -598,7 +598,7 @@ K2PgStatus PgGate_ExecInsert(K2PgOid database_oid,
         if (!kPgRowIdProvided) {
             // generate a row_id to populate the kPgRowId column
             std::string row_id = k2pg::pg_session->GenerateNewRowid();
-            char* datum = (char*)(palloc(row_id.size() + VARHDRSZ));
+            char* datum = (char*)(palloc0(row_id.size() + VARHDRSZ));
             memcpy(VARDATA(datum), row_id.data(), row_id.size());
             SET_VARSIZE(datum, row_id.size() + VARHDRSZ);
             K2PgAttributeDef kPgRowIdColumn {

--- a/src/gausskernel/storage/access/k2/pg_gate_api.cpp
+++ b/src/gausskernel/storage/access/k2/pg_gate_api.cpp
@@ -534,19 +534,14 @@ K2PgStatus PgGate_DmlFetch(K2PgScanHandle* handle, int32_t nattrs, uint64_t *val
     return status;
 }
 
-// Utility method that checks stmt type and calls either exec insert, update, or delete internally.
-K2PgStatus PgGate_DmlExecWriteOp(K2PgStatement handle, int32_t *rows_affected_count){
-  elog(LOG, "PgGateAPI: PgGate_DmlExecWriteOp");
-  return K2PgStatus::NotSupported;
-}
-
 // This function returns the tuple id (k2pgctid) of a Postgres tuple.
-K2PgStatus PgGate_DmlBuildPgTupleId(Oid db_oid, Oid table_id, const std::vector<K2PgAttributeDef>& attrs,
+K2PgStatus PgGate_DmlBuildPgTupleId(Oid db_oid, Oid table_oid, const std::vector<K2PgAttributeDef>& attrs,
                                     uint64_t *k2pgctid){
     elog(LOG, "PgGateAPI: PgGate_DmlBuildPgTupleId %lu", attrs.size());
 
     skv::http::dto::SKVRecord fullRecord;
-    K2PgStatus status = makeSKVRecordFromK2PgAttributes(db_oid, table_id, attrs, fullRecord);
+    std::shared_ptr<k2pg::PgTableDesc> pg_table = k2pg::pg_session->LoadTable(db_oid, table_oid);
+    K2PgStatus status = makeSKVRecordFromK2PgAttributes(db_oid, table_oid, attrs, fullRecord, pg_table);
     if (status.pg_code != ERRCODE_SUCCESSFUL_COMPLETION) {
         return status;
     }
@@ -584,12 +579,40 @@ K2PgStatus PgGate_ExecInsert(K2PgOid database_oid,
                              K2PgOid table_oid,
                              bool upsert,
                              bool increment_catalog,
-                             const std::vector<K2PgAttributeDef>& columns) {
+                             std::vector<K2PgAttributeDef>& columns) {
     elog(LOG, "PgGateAPI: PgGate_ExecInsert %d, %d", database_oid, table_oid);
     auto catalog = pg_gate->GetCatalogClient();
 
     skv::http::dto::SKVRecord record;
-    K2PgStatus status = makeSKVRecordFromK2PgAttributes(database_oid, table_oid, columns, record);
+    std::shared_ptr<k2pg::PgTableDesc> pg_table = k2pg::pg_session->LoadTable(database_oid, table_oid);
+    // check if the table has k2pgrowid system column
+    if (pg_table->FindColumn(k2pg::to_underlying(k2pg::PgSystemAttrNum::kPgRowId)) != NULL) {
+        // check if k2pgrowid has already been included in passed in columns
+        bool kPgRowIdProvided = false;
+        for (const auto& column: columns) {
+            if (column.attr_num == k2pg::to_underlying(k2pg::PgSystemAttrNum::kPgRowId)) {
+                kPgRowIdProvided = true;
+                break;
+            }
+        }
+        if (!kPgRowIdProvided) {
+            // generate a row_id to populate the kPgRowId column
+            std::string row_id = k2pg::pg_session->GenerateNewRowid();
+            char* datum = (char*)(palloc(row_id.size() + VARHDRSZ));
+            memcpy(VARDATA(datum), row_id.data(), row_id.size());
+            SET_VARSIZE(datum, row_id.size() + VARHDRSZ);
+            K2PgAttributeDef kPgRowIdColumn {
+                .attr_num = k2pg::to_underlying(k2pg::PgSystemAttrNum::kPgRowId),
+                .value = {
+                    .type_id = BYTEAOID,
+                    .datum = PointerGetDatum(datum),
+                    .is_null = false
+                }
+            };
+            columns.push_back(std::move(kPgRowIdColumn));
+        }
+    }
+    K2PgStatus status = makeSKVRecordFromK2PgAttributes(database_oid, table_oid, columns, record, pg_table);
 
     if (status.pg_code != ERRCODE_SUCCESSFUL_COMPLETION) {
         return status;

--- a/src/gausskernel/storage/access/k2/storage.cpp
+++ b/src/gausskernel/storage/access/k2/storage.cpp
@@ -833,8 +833,8 @@ K2PgStatus serializePgAttributesToSKV(skv::http::dto::SKVRecordBuilder& builder,
 
 K2PgStatus makeSKVRecordFromK2PgAttributes(K2PgOid database_oid, K2PgOid table_oid,
                                            const std::vector<K2PgAttributeDef>& columns,
-                                           skv::http::dto::SKVRecord& record) {
-    std::shared_ptr<k2pg::PgTableDesc> pg_table = k2pg::pg_session->LoadTable(database_oid, table_oid);
+                                           skv::http::dto::SKVRecord& record,
+                                           std::shared_ptr<k2pg::PgTableDesc> pg_table) {
     std::unordered_map<int, uint32_t> attr_to_offset;
     for (const auto& column : columns) {
         k2pg::PgColumn *pg_column = pg_table->FindColumn(column.attr_num);

--- a/src/gausskernel/storage/access/k2/storage.h
+++ b/src/gausskernel/storage/access/k2/storage.h
@@ -79,7 +79,7 @@ namespace gate {
     // Serialize a full SKVRecord from the pg columns, the passed in SKVRecord record is an out parameter
     K2PgStatus makeSKVRecordFromK2PgAttributes(K2PgOid database_oid, K2PgOid table_oid,
                                                const std::vector<K2PgAttributeDef>& columns,
-                                               skv::http::dto::SKVRecord& record);
+                                               skv::http::dto::SKVRecord& record, std::shared_ptr<k2pg::PgTableDesc> pg_table);
 
     // builder is an out parameter that is serialized with just the key fields for the record. columns may or may not contain a virtual tupleID attribute,
     // and columns may or may not contain attributes that are not part of the key fields

--- a/src/include/access/k2/pg_gate_api.h
+++ b/src/include/access/k2/pg_gate_api.h
@@ -221,11 +221,6 @@ class K2PgScanHandle;
 K2PgStatus PgGate_DmlFetch(K2PgScanHandle* handle, int32_t natts, uint64_t *values, bool *isnulls,
                         K2PgSysColumns *syscols, bool *has_data);
 
-// Utility method that checks stmt type and calls either exec insert, update, or delete internally.
-// TODO now only used by DDL commands that we do not support right now (e.g. Drop table). It will need
-// to be updated when we add this support.
-K2PgStatus PgGate_DmlExecWriteOp(K2PgStatement handle, int32_t *rows_affected_count);
-
 // This function returns the tuple id (k2pgctid) of a Postgres tuple.
 K2PgStatus PgGate_DmlBuildPgTupleId(Oid db_oid, Oid table_oid, const std::vector<K2PgAttributeDef>& attrs,
                                     uint64_t *k2pgctid);
@@ -238,7 +233,7 @@ K2PgStatus PgGate_ExecInsert(K2PgOid database_oid,
                              K2PgOid table_oid,
                              bool upsert,
                              bool increment_catalog,
-                             const std::vector<K2PgAttributeDef>& columns);
+                             std::vector<K2PgAttributeDef>& columns);
 
 // UPDATE ------------------------------------------------------------------------------------------
 K2PgStatus PgGate_ExecUpdate(K2PgOid database_oid,

--- a/src/include/access/k2/pg_ids.h
+++ b/src/include/access/k2/pg_ids.h
@@ -35,6 +35,11 @@ typedef uint32_t PgOid;
 static constexpr PgOid kPgInvalidOid = 0;
 static constexpr PgOid kPgByteArrayOid = 17;
 
+template <typename E>
+constexpr typename std::underlying_type<E>::type to_underlying(E e) {
+    return static_cast<typename std::underlying_type<E>::type>(e);
+ }
+
 class ObjectIdGenerator {
     public:
     ObjectIdGenerator() {}

--- a/src/include/access/k2/pg_session.h
+++ b/src/include/access/k2/pg_session.h
@@ -94,6 +94,11 @@ public:
         fk_reference_cache_.clear();
     }
 
+    // Generate a new random and unique rowid. It is a v4 UUID.
+    std::string GenerateNewRowid() {
+        return rowid_generator_.Next(true /* binary_id */);
+    }
+
 private:
     std::shared_ptr<k2pg::catalog::SqlCatalogClient> catalog_client_;
 
@@ -108,6 +113,9 @@ private:
     std::string client_id_;
 
     std::atomic<int64_t> stmt_id_;
+
+    // Rowid generator.
+    ObjectIdGenerator rowid_generator_;
 };
 
 }  // namespace k2pg


### PR DESCRIPTION
If a table does not have primary keys, a system column kPgRowId is added to make sure that we have a unique row for the data. Added logic to populate this column with auto-generated uuid if it is not included in the insertion data.

