### PR TITLE
index_only_scan and support for more pggate select constraint types

### DIFF
--- a/src/gausskernel/storage/access/k2/pg_gate_api.cpp
+++ b/src/gausskernel/storage/access/k2/pg_gate_api.cpp
@@ -701,7 +701,7 @@ K2PgStatus PgGate_ExecDelete(K2PgOid database_oid,
     *rows_affected = 0;
     std::unique_ptr<skv::http::dto::SKVRecordBuilder> builder;
 
-    // Get a builder with the keys serialzed. called function handles tupleId attribute if needed
+    // Get a builder with the keys serialized. called function handles tupleId attribute if needed
     K2PgStatus status = makeSKVBuilderWithKeysSerialized(database_oid, table_oid, columns, builder);
     if (status.pg_code != ERRCODE_SUCCESSFUL_COMPLETION) {
         return status;
@@ -799,6 +799,13 @@ K2PgStatus PgGate_NewSelect(K2PgOid database_oid,
     }
     (*handle)->secondarySchema = secondarySchema;
 
+    if (index_params.index_only_scan) {
+        (*handle)->primaryTable = (*handle)->secondaryTable;
+        (*handle)->secondaryTable = nullptr;
+        (*handle)->primarySchema = (*handle)->secondarySchema;
+        (*handle)->secondarySchema = nullptr;
+    }
+
     (*handle)->maxParallelReads = k2pg::TXMgr.getConfig().get<uint32_t>("pggate.max_parallel_reads", 5);
 
     return K2PgStatus::OK;
@@ -830,17 +837,61 @@ K2PgStatus PgGate_ExecSelect(K2PgScanHandle *handle, const std::vector<K2PgConst
 
     std::shared_ptr<skv::http::dto::Schema> schema = handle->secondarySchema ? handle->secondarySchema : handle->primarySchema;
     for (const K2PgConstraintDef& constraint: constraints) {
-        Expression expr = buildScanExpr(handle, constraint, attr_to_offset);
-        if (expr.op == Operation::UNKNOWN) {
-            // Unsupported pg type or operation, it will be processed by pg and not pushed down
-            continue;
-        }
 
-        uint32_t offset = attr_to_offset[constraint.attr_num];
-        if (offset < schema->partitionKeyFields.size()) {
-            range_conds.expressionChildren.push_back(std::move(expr));
-        } else {
-            where_conds.expressionChildren.push_back(std::move(expr));
+        if (constraint.constraint == K2PG_CONSTRAINT_BETWEEN) {
+            // Special case for BETWEEN since SKV does not have a 1:1 match
+            K2PgConstraintDef gteConstraint = constraint;
+            gteConstraint.constraint = K2PG_CONSTRAINT_GTE;
+            gteConstraint.constants.pop_back();
+            Expression gteExpr = buildScanExpr(handle, gteConstraint, attr_to_offset);
+            K2PgConstraintDef lteConstraint = constraint;
+            lteConstraint.constraint = K2PG_CONSTRAINT_LTE;
+            lteConstraint.constants[0] = lteConstraint.constants[1];
+            gteConstraint.constants.pop_back();
+            Expression lteExpr = buildScanExpr(handle, lteConstraint, attr_to_offset);
+
+            uint32_t offset = attr_to_offset[constraint.attr_num];
+            if (offset < schema->partitionKeyFields.size()) {
+                range_conds.expressionChildren.push_back(std::move(gteExpr));
+                range_conds.expressionChildren.push_back(std::move(lteExpr));
+            } else {
+                where_conds.expressionChildren.push_back(std::move(gteExpr));
+                where_conds.expressionChildren.push_back(std::move(lteExpr));
+            }
+        }
+        else if (constraint.constraint == K2PG_CONSTRAINT_IN) {
+            // Special case for IN since SKV does not have a 1:1 match
+            std::vector<Expression> expr_to_add;
+            for (const K2PgConstant& constant : constraint.constants) {
+                K2PgConstraintDef eqConstraint {
+                    .attr_num = constraint.attr_num,
+                    .constraint = K2PG_CONSTRAINT_EQ,
+                    .constants = std::vector<K2PgConstant>{constant}
+                };
+                Expression expr = buildScanExpr(handle, eqConstraint, attr_to_offset);
+                expr_to_add.push_back(std::move(expr));
+            }
+
+            Expression or_expr{};
+            or_expr.op = Operation::OR;
+            or_expr.expressionChildren = std::move(expr_to_add);
+            // Expressions with OR must always be where clause not range
+            where_conds.expressionChildren.push_back(std::move(or_expr));
+        }
+        else {
+            // Normal case of 1 constant expression that has 1:1 map to SKV expression
+            Expression expr = buildScanExpr(handle, constraint, attr_to_offset);
+            if (expr.op == Operation::UNKNOWN) {
+                // Unsupported pg type or operation, it will be processed by pg and not pushed down
+                continue;
+            }
+
+            uint32_t offset = attr_to_offset[constraint.attr_num];
+            if (offset < schema->partitionKeyFields.size()) {
+                range_conds.expressionChildren.push_back(std::move(expr));
+            } else {
+                where_conds.expressionChildren.push_back(std::move(expr));
+            }
         }
     }
 
@@ -892,6 +943,10 @@ K2PgStatus PgGate_ExecSelect(K2PgScanHandle *handle, const std::vector<K2PgConst
     int limit = -1;
     if (!limit_params.limit_use_default && limit_params.limit_count > 0) {
         limit = limit_params.limit_count + limit_params.limit_offset;
+    }
+
+    if (!where_conds.expressionChildren.size()) {
+        where_conds = Expression();
     }
 
     auto [status, query] = k2pg::TXMgr.createQuery(start.build(), end.build(), std::move(where_conds), std::move(projection), limit, !forward_scan).get();

--- a/src/gausskernel/storage/access/k2/storage.cpp
+++ b/src/gausskernel/storage/access/k2/storage.cpp
@@ -553,9 +553,18 @@ skv::http::dto::expression::Expression buildScanExpr(K2PgScanHandle* scan, const
         case K2PgConstraintType::K2PG_CONSTRAINT_EQ: //  equal =
             opr_expr.op = expression::Operation::EQ;
             break;
-        // TODO support for between and in
-        case K2PgConstraintType::K2PG_CONSTRAINT_BETWEEN:
-        case K2PgConstraintType::K2PG_CONSTRAINT_IN:
+        case K2PgConstraintType::K2PG_CONSTRAINT_LT:
+            opr_expr.op = expression::Operation::LT;
+            break;
+        case K2PgConstraintType::K2PG_CONSTRAINT_LTE:
+            opr_expr.op = expression::Operation::LTE;
+            break;
+        case K2PgConstraintType::K2PG_CONSTRAINT_GT:
+            opr_expr.op = expression::Operation::GT;
+            break;
+        case K2PgConstraintType::K2PG_CONSTRAINT_GTE:
+            opr_expr.op = expression::Operation::GTE;
+            break;
         default:
             K2LOG_W(log::k2pg, "Ignoring scan constraint of type: {}", constraint.constraint);
             return opr_expr;

--- a/src/include/access/k2/pg_gate_api.h
+++ b/src/include/access/k2/pg_gate_api.h
@@ -198,9 +198,12 @@ struct K2PgConstant {
 enum K2PgConstraintType {
     K2PG_CONSTRAINT_UNKNOWN,
     K2PG_CONSTRAINT_EQ,
+    K2PG_CONSTRAINT_LT,
+    K2PG_CONSTRAINT_LTE,
+    K2PG_CONSTRAINT_GT,
+    K2PG_CONSTRAINT_GTE,
     K2PG_CONSTRAINT_BETWEEN,
     K2PG_CONSTRAINT_IN
-    // TODO Add constraints needed by user scan
 };
 
 struct K2PgConstraintDef {


### PR DESCRIPTION
index_only_scan is implemented simply as a normal query over the secondary index/schema. That is the constraints and targets are interpreted as applying directly to the secondary index. This seems to match the way chogori-sql implemented it.

Added LT, LTE, GT, GTE, IN, and BETWEEN support to pggate select. IN is implemented as a set of OR'ed EQ clauses. BETWEEN is expanded as LTE and GTE pair. Everything is has a direct mapping to SKV expression.