### PR TITLE
refactor k2index definition and add op classes for it

### DIFF
--- a/src/common/backend/catalog/builtin_funcs.ini
+++ b/src/common/backend/catalog/builtin_funcs.ini
@@ -11680,3 +11680,51 @@
         "zhprs_start", 1,
         AddBuiltinFunc(_0(3792), _1("zhprs_start"), _2(3), _3(true), _4(false), _5(zhprs_start), _6(2281), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('i'), _19(0), _20(3, 2281, 23, 26), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("zhprs_start"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
     ),
+    AddFuncGroup(
+        "k2inbuild", 1,
+        AddBuiltinFunc(_0(10033), _1("k2inbuild"), _2(3), _3(true), _4(false), _5(k2inbuild), _6(2281), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(3, 2281, 2281, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2inbuild"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2inbuildempty", 1,
+        AddBuiltinFunc(_0(10034), _1("k2inbuildempty"), _2(1), _3(true), _4(false), _5(k2inbuildempty), _6(2278), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(1, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2inbuildempty"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2ininsert", 1,
+        AddBuiltinFunc(_0(10035), _1("k2ininsert"), _2(6), _3(true), _4(false), _5(k2ininsert), _6(16), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(6, 2281, 2281, 2281, 2281, 2281, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2ininsert"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2inbeginscan", 1,
+        AddBuiltinFunc(_0(10036), _1("k2inbeginscan"), _2(3), _3(true), _4(false), _5(k2inbeginscan), _6(2281), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(3, 2281, 2281, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2inbeginscan"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2inendscan", 1,
+        AddBuiltinFunc(_0(10037), _1("k2inendscan"), _2(1), _3(true), _4(false), _5(btendscan), _6(2278), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(1, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2inendscan"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2inrescan", 1,
+        AddBuiltinFunc(_0(10038), _1("k2inrescan"), _2(5), _3(true), _4(false), _5(k2inrescan), _6(2278), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(5, 2281, 2281, 2281, 2281, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2inrescan"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2ingettuple", 1,
+        AddBuiltinFunc(_0(10039), _1("k2ingettuple"), _2(2), _3(true), _4(false), _5(k2ingettuple), _6(16), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(2, 2281, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2ingettuple"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2inbulkdelete", 1,
+        AddBuiltinFunc(_0(10040), _1("k2inbulkdelete"), _2(4), _3(true), _4(false), _5(k2inbulkdelete), _6(2281), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(4, 2281, 2281, 2281, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2inbulkdelete"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2incanreturn", 1,
+        AddBuiltinFunc(_0(10041), _1("k2incanreturn"), _2(1), _3(true), _4(false), _5(k2incanreturn), _6(16), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('s'), _19(0), _20(1, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2incanreturn"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2inoptions", 1,
+        AddBuiltinFunc(_0(10042), _1("k2inoptions"), _2(2), _3(true), _4(false), _5(k2inoptions), _6(17), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('s'), _19(0), _20(2, 1009, 16), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2inoptions"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2incostestimate", 1,
+        AddBuiltinFunc(_0(10043), _1("k2incostestimate"), _2(7), _3(true), _4(false), _5(btcostestimate), _6(2278), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(7, 2281, 2281, 2281, 2281, 2281, 2281, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2incostestimate"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),
+    AddFuncGroup(
+        "k2invacuumcleanup", 1,
+        AddBuiltinFunc(_0(10044), _1("k2invacuumcleanup"), _2(2), _3(true), _4(false), _5(k2invacuumcleanup), _6(2281), _7(PG_CATALOG_NAMESPACE), _8(BOOTSTRAP_SUPERUSERID), _9(INTERNALlanguageId), _10(1), _11(0), _12(0), _13(0), _14(false), _15(false), _16(false), _17(false), _18('v'), _19(0), _20(2, 2281, 2281), _21(NULL), _22(NULL), _23(NULL), _24(NULL), _25("k2invacuumcleanup"), _26(NULL), _27(NULL), _28(NULL), _29(0), _30(false), _31(NULL), _32(false), _33(NULL), _34('f'), _35(NULL),  _36(0), _37(false))
+    ),

--- a/src/gausskernel/storage/access/k2/config.cpp
+++ b/src/gausskernel/storage/access/k2/config.cpp
@@ -32,7 +32,7 @@ Config::Config() {
     }
 
     // read the config file
-    K2LOG_I(log::k2pg, "{}", configFileName);
+    K2LOG_D(log::k2pg, "{}", configFileName);
     std::ifstream ifile(configFileName);
     ifile >> _config;
 }

--- a/src/gausskernel/storage/access/k2/k2_table_ops.cpp
+++ b/src/gausskernel/storage/access/k2/k2_table_ops.cpp
@@ -310,7 +310,9 @@ static Oid K2PgExecuteInsertInternal(Relation rel,
 	bool is_syscatalog_change = IsSystemCatalogChange(rel) && RelationHasCachedLists(rel);
 
 	/* Execute the insert */
-	HandleK2PgStatus(PgGate_ExecInsert(dboid, relid, false /* upsert */, is_syscatalog_change, columns));
+        Datum k2pgtid = 0;
+        HandleK2PgStatus(PgGate_ExecInsert(dboid, relid, false /* upsert */, is_syscatalog_change, columns, &k2pgtid));
+        tuple->t_k2pgctid = k2pgtid;
 
 	/*
 	 * Optimization to increment the catalog version for the local cache as
@@ -454,7 +456,8 @@ void K2PgExecuteInsertIndex(Relation index,
 	}
 
 	/* Execute the insert and clean up. */
-	HandleK2PgStatus(PgGate_ExecInsert(dboid, relid, upsert, false, columns));
+	Datum k2pgtid = 0;
+	HandleK2PgStatus(PgGate_ExecInsert(dboid, relid, upsert, false, columns, &k2pgtid));
 }
 
 bool K2PgExecuteDelete(Relation rel, TupleTableSlot *slot, EState *estate, ModifyTableState *mtstate)

--- a/src/gausskernel/storage/access/k2/k2catam.cpp
+++ b/src/gausskernel/storage/access/k2/k2catam.cpp
@@ -572,8 +572,7 @@ ShouldPushdownScanKey(Relation relation, CamScanPlan scan_plan, AttrNumber attnu
 		 * TODO: we can probably allow ineq conditions for system tables now.
 		 */
 		return IsBasicOpSearch(key->sk_flags) &&
-			key->sk_strategy == BTEqualStrategyNumber &&
-			is_primary_key;
+			key->sk_strategy == BTEqualStrategyNumber;
 	}
 	else
 	{
@@ -650,8 +649,7 @@ static void	camSetupScanKeys(Relation relation,
 			continue;
 		}
 
-		if (is_primary_key)
-			scan_plan->sk_cols = bms_add_member(scan_plan->sk_cols, idx);
+		scan_plan->sk_cols = bms_add_member(scan_plan->sk_cols, idx);
 	}
 
 	/*

--- a/src/gausskernel/storage/access/k2/storage.cpp
+++ b/src/gausskernel/storage/access/k2/storage.cpp
@@ -702,8 +702,12 @@ K2PgStatus makeSKVBuilderWithKeysSerialized(K2PgOid database_oid, K2PgOid table_
                 return status;
             }
 
-        record = tupleIDDatumToSKVRecord(attribute.value.datum, builder->getCollectionName(), builder->getSchema());
-        use_tupleID = true;
+            if (attribute.value.datum != 0) {
+                record = tupleIDDatumToSKVRecord(attribute.value.datum, builder->getCollectionName(), builder->getSchema());
+                use_tupleID = true;
+            } else {
+                K2LOG_W(log::k2pg, "TupeId is NULL in makeSKVBuilderWithKeys for schema {}", *(builder->getSchema()));
+            }
         }
     }
 

--- a/src/include/access/k2/k2_index_ops.h
+++ b/src/include/access/k2/k2_index_ops.h
@@ -30,37 +30,20 @@ Copyright(c) 2022 Futurewei Cloud
 /*
  * external entry points for K2PG indexes
  */
-extern IndexBuildResult *k2inbuild(Relation heap, Relation index, struct IndexInfo *indexInfo);
-extern void k2inbuildempty(Relation index);
-extern bool k2ininsert(Relation rel, Datum *values, bool *isnull, Datum k2pgctid, Relation heapRel,
-						IndexUniqueCheck checkUnique, struct IndexInfo *indexInfo);
-extern void k2indelete(Relation rel, Datum *values, bool *isnull, Datum k2pgctid, Relation heapRel,
-						struct IndexInfo *indexInfo);
-
-extern IndexBulkDeleteResult *k2inbulkdelete(IndexVacuumInfo *info,
-											  IndexBulkDeleteResult *stats,
-											  IndexBulkDeleteCallback callback,
-											  void *callback_state);
-extern IndexBulkDeleteResult *k2invacuumcleanup(IndexVacuumInfo *info,
-												 IndexBulkDeleteResult *stats);
-
-extern bool k2incanreturn(Relation index, int attno);
-extern void k2incostestimate(struct PlannerInfo *root,
-							  struct IndexPath *path,
-							  double loop_count,
-							  Cost *indexStartupCost,
-							  Cost *indexTotalCost,
-							  Selectivity *indexSelectivity,
-							  double *indexCorrelation,
-							  double *indexPages);
-extern bytea *k2inoptions(Datum reloptions, bool validate);
+extern Datum k2inbuild(PG_FUNCTION_ARGS);
+extern Datum k2inbuildempty(PG_FUNCTION_ARGS);
+extern Datum k2ininsert(PG_FUNCTION_ARGS);
+extern Datum k2inbeginscan(PG_FUNCTION_ARGS);
+extern Datum k2ingettuple(PG_FUNCTION_ARGS);
+extern Datum k2inrescan(PG_FUNCTION_ARGS);
+extern Datum k2inendscan(PG_FUNCTION_ARGS);
+extern Datum k2indelete(PG_FUNCTION_ARGS);
+extern Datum k2inbulkdelete(PG_FUNCTION_ARGS);
+extern Datum k2invacuumcleanup(PG_FUNCTION_ARGS);
+extern Datum k2incanreturn(PG_FUNCTION_ARGS);
+extern Datum k2inoptions(PG_FUNCTION_ARGS);
+extern Datum k2incostestimate(PG_FUNCTION_ARGS);
 
 extern bool k2invalidate(Oid opclassoid);
-
-extern IndexScanDesc k2inbeginscan(Relation rel, int nkeys, int norderbys);
-extern void k2inrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
-						ScanKey orderbys, int norderbys);
-extern bool k2ingettuple(IndexScanDesc scan, ScanDirection dir);
-extern void k2inendscan(IndexScanDesc scan);
 
 #endif							/* K2_INDEX_OPS_H */

--- a/src/include/access/k2/k2_types.h
+++ b/src/include/access/k2/k2_types.h
@@ -36,7 +36,7 @@ namespace k2pg {
 // These are types that we can push down filter operations to K2, so when we convert them we want to
 // strip out the Datum headers
 inline bool isStringType(Oid oid) {
-    return (oid == VARCHAROID || oid == BPCHAROID || oid == TEXTOID || oid == CLOBOID || oid == CSTRINGOID);
+    return (oid == VARCHAROID || oid == BPCHAROID || oid == TEXTOID || oid == CLOBOID || oid == CSTRINGOID || oid == BYTEAOID);
 }
 
 // Type to size association taken from MOT column.cpp. Note that this does not determine whether we can use the type as a key or for pushdown, only that it will fit in a K2 native type

--- a/src/include/access/k2/pg_gate_api.h
+++ b/src/include/access/k2/pg_gate_api.h
@@ -233,7 +233,8 @@ K2PgStatus PgGate_ExecInsert(K2PgOid database_oid,
                              K2PgOid table_oid,
                              bool upsert,
                              bool increment_catalog,
-                             std::vector<K2PgAttributeDef>& columns);
+                             std::vector<K2PgAttributeDef>& columns,
+                             Datum* k2pgtupleid);
 
 // UPDATE ------------------------------------------------------------------------------------------
 K2PgStatus PgGate_ExecUpdate(K2PgOid database_oid,

--- a/src/include/catalog/pg_am.h
+++ b/src/include/catalog/pg_am.h
@@ -152,9 +152,9 @@ DATA(insert OID = 4439 (  ubtree		5 2 t f t t t t t t f t t 0 ubtinsert ubtbegin
 DESCR("ustore b-tree index access method");
 #define UBTREE_AM_OID 4439
 
-DATA(insert OID = 9901 (  k2index		5 3 t f t t t t t t f t t 0 k2ininsert k2inbeginscan k2ingettuple - k2inrescan k2inendscan - - - k2inbuild k2inbuildempty k2inbulkdelete k2invacuumcleanup k2incanreturn k2incostestimate k2inoptions));
+DATA(insert OID = 10030 (  k2index		5 3 t f t t t t t t f t t 0 k2ininsert k2inbeginscan k2ingettuple - k2inrescan k2inendscan - - - k2inbuild k2inbuildempty k2inbulkdelete k2invacuumcleanup k2incanreturn k2incostestimate k2inoptions));
 DESCR("k2 b-tree index access method");
-#define K2INDEX_AM_OID 9901
+#define K2INDEX_AM_OID 10030
 
 #define OID_IS_BTREE(oid) ((oid) == BTREE_AM_OID || (oid) == UBTREE_AM_OID)
 

--- a/src/include/catalog/pg_opclass.h
+++ b/src/include/catalog/pg_opclass.h
@@ -367,5 +367,41 @@ DATA(insert ( 405     jsonb_ops        PGNSP    PGUID  4034  3802 t 0 ));
 DATA(insert ( 2742    jsonb_ops        PGNSP    PGUID  4036  3802 t 25 ));
 DATA(insert ( 2742    jsonb_hash_ops   PGNSP    PGUID  4037  3802 f 23 ));
 
+/* k2index index to make index work */
+DATA(insert ( 10030    int4_ops         PGNSP    PGUID  10050    23    t    0));
+DATA(insert ( 10030    int2_ops         PGNSP    PGUID  10050    21    t    0));
+DATA(insert ( 10030    int8_ops         PGNSP    PGUID  10050    20    t    0));
+DATA(insert ( 10030    oid_ops          PGNSP    PGUID  10051    26    t    0));
+DATA(insert ( 10030    date_ops         PGNSP    PGUID  10052  1082    t    0));
+DATA(insert ( 10030    timestamp_ops    PGNSP    PGUID  10052  1114    t    0));
+DATA(insert ( 10030    timestamptz_ops  PGNSP    PGUID  10052  1184    t    0));
+DATA(insert ( 10030    float4_ops       PGNSP    PGUID  10053   700    t    0));
+DATA(insert ( 10030    float8_ops       PGNSP    PGUID  10053   701    t    0));
+DATA(insert ( 10030    numeric_ops      PGNSP    PGUID  10054  1700    t    0));
+DATA(insert ( 10030    text_ops         PGNSP    PGUID  10055    25    t    0));
+DATA(insert ( 10030    bpchar_ops       PGNSP    PGUID  10056  1042    t    0));
+DATA(insert ( 10030    time_ops         PGNSP    PGUID  10057  1083    t    0));
+DATA(insert ( 10030    timetz_ops       PGNSP    PGUID  10058  1266    t    0));
+DATA(insert ( 10030    money_ops        PGNSP    PGUID  10059   790    t    0));
+DATA(insert ( 10030    interval_ops     PGNSP    PGUID  10060  1186    t    0));
+DATA(insert ( 10030    tinterval_ops    PGNSP    PGUID  10061   704    t    0));
+DATA(insert ( 10030    int1_ops         PGNSP    PGUID  10062  5545    t    0));
+DATA(insert ( 10030    bool_ops         PGNSP    PGUID  10063    16    t    0));
+DATA(insert ( 10030    smalldatetime_ops  PGNSP  PGUID  10064  9003    t    0));
+DATA(insert ( 10030    name_ops         PGNSP    PGUID  10065   19     t    0));
+DATA(insert ( 10030    char_ops         PGNSP    PGUID  10066   18     t    0));
+DATA(insert ( 10030    array_ops        PGNSP    PGUID  10067   2277   t    0));
+DATA(insert ( 10030    bit_ops          PGNSP    PGUID  10068   1560   t    0));
+DATA(insert ( 10030    bytea_ops        PGNSP    PGUID  10069   17     t    0));
+DATA(insert ( 10030    abstime_ops      PGNSP    PGUID  10070   702    t    0));
+DATA(insert ( 10030    oidvector_ops    PGNSP    PGUID  10072   30     t    0));
+DATA(insert ( 10030    record_ops       PGNSP    PGUID  10073   2249   t    0));
+DATA(insert ( 10030    varbit_ops       PGNSP    PGUID  10074   1562   t    0));
+DATA(insert ( 10030    tid_ops          PGNSP    PGUID  10075   27     t    0));
+DATA(insert ( 10030    xid_ops          PGNSP    PGUID  10076   28     t    0));
+DATA(insert ( 10030    cid_ops          PGNSP    PGUID  10077   29     t    0));
+DATA(insert ( 10030    macaddr_ops      PGNSP    PGUID  10078   829    t    0));
+
+
 #endif   /* PG_OPCLASS_H */
 

--- a/src/include/catalog/pg_opfamily.h
+++ b/src/include/catalog/pg_opfamily.h
@@ -289,5 +289,36 @@ DATA(insert OID = 8806 (4439       raw_ops         PGNSP PGUID));
 DATA(insert OID = 9535 (4439       int1_ops         PGNSP PGUID));
 DATA(insert OID = 9570 (4439       smalldatetime_ops         PGNSP PGUID));
 
+// k2index op family to make index work
+DATA(insert OID = 10050 (10030    integer_ops      PGNSP    PGUID));
+DATA(insert OID = 10051 (10030    oid_ops          PGNSP    PGUID));
+DATA(insert OID = 10052 (10030    datetime_ops     PGNSP    PGUID));
+DATA(insert OID = 10053 (10030    float_ops        PGNSP    PGUID));
+DATA(insert OID = 10054 (10030    numeric_ops      PGNSP    PGUID));
+DATA(insert OID = 10055 (10030    text_ops         PGNSP    PGUID));
+DATA(insert OID = 10056 (10030    bpchar_ops       PGNSP    PGUID));
+DATA(insert OID = 10057 (10030    time_ops         PGNSP    PGUID));
+DATA(insert OID = 10058 (10030    timetz_ops       PGNSP    PGUID));
+DATA(insert OID = 10059 (10030    money_ops        PGNSP    PGUID));
+DATA(insert OID = 10060 (10030    interval_ops     PGNSP    PGUID));
+DATA(insert OID = 10061 (10030    tinterval_ops    PGNSP    PGUID));
+DATA(insert OID = 10062 (10030    int1_ops         PGNSP    PGUID));
+DATA(insert OID = 10063 (10030    bool_ops         PGNSP    PGUID));
+DATA(insert OID = 10064 (10030    smalldatetime_ops  PGNSP  PGUID));
+DATA(insert OID = 10065 (10030    name_ops         PGNSP    PGUID));
+DATA(insert OID = 10066 (10030    char_ops         PGNSP    PGUID));
+DATA(insert OID = 10067 (10030    array_ops        PGNSP    PGUID));
+DATA(insert OID = 10068 (10030    bit_ops          PGNSP    PGUID));
+DATA(insert OID = 10069 (10030    bytea_ops        PGNSP    PGUID));
+DATA(insert OID = 10070 (10030    abstime_ops      PGNSP    PGUID));
+DATA(insert OID = 10071 (10030    network_ops      PGNSP    PGUID));
+DATA(insert OID = 10072 (10030    oidvector_ops    PGNSP    PGUID));
+DATA(insert OID = 10073 (10030    record_ops       PGNSP    PGUID));
+DATA(insert OID = 10074 (10030    varbit_ops       PGNSP    PGUID));
+DATA(insert OID = 10075 (10030    tid_ops          PGNSP    PGUID));
+DATA(insert OID = 10076 (10030    xid_ops          PGNSP    PGUID));
+DATA(insert OID = 10077 (10030    cid_ops          PGNSP    PGUID));
+DATA(insert OID = 10078 (10030    macaddr_ops      PGNSP    PGUID));
+
 #endif   /* PG_OPFAMILY_H */
 


### PR DESCRIPTION
1) Refactored k2index definition to PG 9.2 format
2) Added k2index to builtin_funcs.ini
3) Added op class family for k2index
4) changed k2index oids to be range 10030-10080 (not used uid range)
5) fixed the NULL pg tuple id issue
6) enable non-primary key pushdown for catalog system table scan
7) ported the tuple id api changes from justin's branch
8) fine tuned some debug log levels 