### PR TITLE
Allow Indexes that do not support range scans

### DIFF
--- a/src/gausskernel/storage/access/k2/catalog/table_info_handler.cpp
+++ b/src/gausskernel/storage/access/k2/catalog/table_info_handler.cpp
@@ -952,16 +952,18 @@ std::shared_ptr<sh::dto::Schema> TableInfoHandler::DeriveIndexSchema(const Index
                 field.nullLast = false;
             } break;
             case ColumnSchema::SortingType::kDescending: {
-                K2LOG_W(log::catalog, "Descending secondary indexes are not supported, see issue #268");
-                return nullptr;
+                K2LOG_W(log::catalog, "Descending secondary indexes are not supported, will be equivalent to ascending");
+                field.descending = true;
+                field.nullLast = false;
             } break;
             case ColumnSchema::SortingType::kAscendingNullsLast: {
                 field.descending = false;
                 field.nullLast = true;
             } break;
             case ColumnSchema::SortingType::kDescendingNullsLast: {
-                K2LOG_W(log::catalog, "Descending secondary indexes are not supported, see issue #268");
-                return nullptr;
+                K2LOG_W(log::catalog, "Descending secondary indexes are not supported, will be equivalent to ascending");
+                field.descending = true;
+                field.nullLast = true;
             } break;
             default: break;
         }

--- a/src/gausskernel/storage/access/k2/k2cat_cmds.cpp
+++ b/src/gausskernel/storage/access/k2/k2cat_cmds.cpp
@@ -305,16 +305,21 @@ K2PgCreateIndex(const char *indexName,
 
 		if (is_key)
 		{
-			if (!K2PgAllowForPrimaryKey(att->atttypid))
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("INDEX on column of type '%s' not yet supported",
-								K2PgTypeOidToStr(att->atttypid))));
+			if (!K2PgAllowForPrimaryKey(att->atttypid)) {
+						 elog(LOG, "INDEX on column of type '%s' not yet supported",
+								K2PgTypeOidToStr(att->atttypid));
+                return;
+            }
 		}
 
 		const int16 options        = coloptions[i];
 		const bool  is_desc        = options & INDOPTION_DESC;
 		const bool  is_nulls_first = options & INDOPTION_NULLS_FIRST;
+
+        if (is_desc) {
+             elog(LOG, "DESC INDEX on column of type not yet supported");
+            return;
+        }
 
         K2PGColumnDef column {
             .attr_name = attname,

--- a/src/gausskernel/storage/access/k2/k2cat_cmds.cpp
+++ b/src/gausskernel/storage/access/k2/k2cat_cmds.cpp
@@ -288,8 +288,7 @@ K2PgCreateIndex(const char *indexName,
 	char *db_name	  = get_database_name(u_sess->proc_cxt.MyDatabaseId);
 	char *schema_name = get_namespace_name(RelationGetNamespace(rel));
 
-	if (!IsBootstrapProcessingMode())
-		elog(INFO, "Creating index %s.%s.%s",
+	elog(INFO, "Creating index %s.%s.%s",
 					 db_name,
 					 schema_name,
 					 indexName);
@@ -306,20 +305,14 @@ K2PgCreateIndex(const char *indexName,
 		if (is_key)
 		{
 			if (!K2PgAllowForPrimaryKey(att->atttypid)) {
-						 elog(LOG, "INDEX on column of type '%s' not yet supported",
-								K2PgTypeOidToStr(att->atttypid));
-                return;
+                 elog(WARNING, "INDEX on column of type '%s' is only supported for uniqueness not ordering",
+                        K2PgTypeOidToStr(att->atttypid));
             }
 		}
 
 		const int16 options        = coloptions[i];
 		const bool  is_desc        = options & INDOPTION_DESC;
 		const bool  is_nulls_first = options & INDOPTION_NULLS_FIRST;
-
-        if (is_desc) {
-             elog(LOG, "DESC INDEX on column of type not yet supported");
-            return;
-        }
 
         K2PGColumnDef column {
             .attr_name = attname,

--- a/src/include/access/k2/storage.h
+++ b/src/include/access/k2/storage.h
@@ -62,7 +62,7 @@ namespace gate {
                                                           std::shared_ptr<skv::http::dto::Schema> primarySchema);
 
     void BuildRangeRecords(skv::http::dto::expression::Expression& range_conds, std::vector<skv::http::dto::expression::Expression>& leftover_exprs,
-                           skv::http::dto::SKVRecordBuilder& start, skv::http::dto::SKVRecordBuilder& end);
+                           skv::http::dto::SKVRecordBuilder& start, skv::http::dto::SKVRecordBuilder& end, bool& isRangeScan);
 
     skv::http::dto::expression::Value serializePGConstToValue(const K2PgConstant& constant);
 


### PR DESCRIPTION
K2 does not support all types in key fields and also does not support descending key ordering. This allows us to create indexes of with these properties but only allow full table or single key lookups from them.