### PR TITLE
Fixes for K2SysCache

### DIFF
--- a/src/common/backend/catalog/indexing.cpp
+++ b/src/common/backend/catalog/indexing.cpp
@@ -273,7 +273,7 @@ void CatalogUpdateIndexes(Relation heapRel, HeapTuple heapTuple)
 
 		K2PgUpdateSysCatalogTuple(heapRel, oldtup, heapTuple);
 		/* Update the local cache automatically */
-//		K2PgSetSysCacheTuple(heapRel, heapTuple);
+		K2PgSetSysCacheTuple(heapRel, heapTuple);
 
 		if (has_indices)
 			CatalogIndexInsert(indstate, heapTuple);
@@ -290,6 +290,7 @@ Oid CatalogTupleInsert(Relation heapRel, HeapTuple tup)
 
 	if (IsK2PgRelation(heapRel)) {
 		oid = K2PgExecuteInsert(heapRel, RelationGetDescr(heapRel), tup);
+		K2PgSetSysCacheTuple(heapRel, tup);
 	} else {
 		oid = simple_heap_insert(heapRel, tup);
 	}

--- a/src/common/backend/utils/cache/syscache.cpp
+++ b/src/common/backend/utils/cache/syscache.cpp
@@ -100,7 +100,6 @@
 #include "utils/rel_gs.h"
 #include "utils/syscache.h"
 #include "catalog/pg_user_status.h"
-#include <vector>
 
 /* ---------------------------------------------------------------------------
 
@@ -761,8 +760,6 @@ static const struct cachedesc cacheinfo[] = {{AggregateRelationId, /* AGGFNOID *
 
 int SysCacheSize = lengthof(cacheinfo);
 
-static std::vector<CatCache *> SysCache(SysCacheSize);
-
 /*
  * InitCatalogCache - initialize the caches
  *
@@ -1162,20 +1159,20 @@ void K2PgSetSysCacheTuple(Relation rel, HeapTuple tup)
 	switch (RelationGetRelid(rel))
 	{
 		case RelationRelationId:
-			SetCatCacheTuple(SysCache[RELOID], tup, tupdesc);
-			SetCatCacheTuple(SysCache[RELNAMENSP], tup, tupdesc);
+			SetCatCacheTuple(u_sess->syscache_cxt.SysCache[RELOID], tup, tupdesc);
+			SetCatCacheTuple(u_sess->syscache_cxt.SysCache[RELNAMENSP], tup, tupdesc);
 			break;
 		case TypeRelationId:
-			SetCatCacheTuple(SysCache[TYPEOID], tup, tupdesc);
-			SetCatCacheTuple(SysCache[TYPENAMENSP], tup, tupdesc);
+			SetCatCacheTuple(u_sess->syscache_cxt.SysCache[TYPEOID], tup, tupdesc);
+			SetCatCacheTuple(u_sess->syscache_cxt.SysCache[TYPENAMENSP], tup, tupdesc);
 			break;
 		case ProcedureRelationId:
-			SetCatCacheTuple(SysCache[PROCOID], tup, tupdesc);
-			SetCatCacheTuple(SysCache[PROCNAMEARGSNSP], tup, tupdesc);
+			SetCatCacheTuple(u_sess->syscache_cxt.SysCache[PROCOID], tup, tupdesc);
+			SetCatCacheTuple(u_sess->syscache_cxt.SysCache[PROCNAMEARGSNSP], tup, tupdesc);
 			break;
 		case AttributeRelationId:
-			SetCatCacheTuple(SysCache[ATTNUM], tup, tupdesc);
-			SetCatCacheTuple(SysCache[ATTNAME], tup, tupdesc);
+			SetCatCacheTuple(u_sess->syscache_cxt.SysCache[ATTNUM], tup, tupdesc);
+			SetCatCacheTuple(u_sess->syscache_cxt.SysCache[ATTNAME], tup, tupdesc);
 			break;
 
 		default:
@@ -1192,8 +1189,8 @@ void
 K2PgPreloadCatalogCache(int cache_id, int idx_cache_id)
 {
 
-	CatCache* cache         = SysCache[cache_id];
-	CatCache* idx_cache     = idx_cache_id != -1 ? SysCache[idx_cache_id] : NULL;
+	CatCache* cache         = u_sess->syscache_cxt.SysCache[cache_id];
+	CatCache* idx_cache     = idx_cache_id != -1 ? u_sess->syscache_cxt.SysCache[idx_cache_id] : NULL;
 	List*     current_list  = NIL;
 	List*     list_of_lists = NIL;
 	HeapTuple ntp;

--- a/src/include/access/itup.h
+++ b/src/include/access/itup.h
@@ -145,13 +145,9 @@ extern IndexTuple CopyIndexTupleAndReserveSpace(IndexTuple source, Size reserved
 
 #define HEAPTUPLE_COPY_K2PGTID(src, dest)                            \
     do {                                                            \
-        if (IsK2Mode()) {                                  \
             dest = (src == 0) ? 0 :                                 \
                 PointerGetDatum(cstring_to_text_with_len(VARDATA_ANY(src), \
                                                          VARSIZE_ANY_EXHDR(src))); \
-        } else {                                                    \
-            dest = 0;                                               \
-        }                                                           \
     } while (false)
 
 #endif /* ITUP_H */


### PR DESCRIPTION
Fixes for the k2 integration with the SysCache. This fixes the k2 update calls without a k2pgctid