### PR TITLE
Init backend fix

### DIFF
--- a/src/common/backend/catalog/genbki.pl
+++ b/src/common/backend/catalog/genbki.pl
@@ -259,10 +259,10 @@ foreach my $catname (@{ $catalogs->{names} })
 # (i.e., not contained in a header with a CATALOG() statement) comes here
 
 # Write out declare toast/index statements
-foreach my $declaration (@{ $catalogs->{toasting}->{data} })
-{
-	print BKI $declaration;
-}
+# foreach my $declaration (@{ $catalogs->{toasting}->{data} })
+# {
+# 	print BKI $declaration;
+# }
 
 foreach my $declaration (@{ $catalogs->{indexing}->{data} })
 {

--- a/src/common/backend/catalog/index.cpp
+++ b/src/common/backend/catalog/index.cpp
@@ -2991,8 +2991,6 @@ double IndexBuildHeapScan(Relation heapRelation, Relation indexRelation, IndexIn
     econtext = GetPerTupleExprContext(estate);
     slot = MakeSingleTupleTableSlot(RelationGetDescr(heapRelation));
 
-//	K2PgSelectLimitParams *exec_params = &estate->k2pg_exec_params;
-
     /* Arrange for econtext's scan tuple to be the tuple under test */
     econtext->ecxt_scantuple = slot;
 
@@ -3026,8 +3024,6 @@ double IndexBuildHeapScan(Relation heapRelation, Relation indexRelation, IndexIn
             NULL,                                 /* scan key */
             true,                                 /* buffer access strategy OK */
             allow_sync);                          /* syncscan OK? */
- 		// if (IsK2PgRelation(heapRelation))
-		// 	scan->k2scan->exec_params = exec_params;
     } else {
         /*
          * Parallel index build.

--- a/src/common/backend/utils/cache/relcache.cpp
+++ b/src/common/backend/utils/cache/relcache.cpp
@@ -4817,10 +4817,13 @@ void RelationCacheInitializePhase2(void)
 {
     MemoryContext oldcxt;
 
-    /*
-     * relation mapper needs initialized too
-     */
-    RelationMapInitializePhase2();
+	/* We do not use a relation map file in K2PG mode yet */
+	if (!IsK2PgEnabled()) {
+        /*
+        * relation mapper needs initialized too
+        */
+        RelationMapInitializePhase2();
+    }
 
     /*
      * In bootstrap mode, the shared catalogs aren't there yet anyway, so do

--- a/src/gausskernel/process/tcop/postgres.cpp
+++ b/src/gausskernel/process/tcop/postgres.cpp
@@ -7310,6 +7310,9 @@ int PostgresMain(int argc, char* argv[], const char* dbname, const char* usernam
      */
     t_thrd.proc_cxt.PostInit->SetDatabaseAndUser(dbname, InvalidOid, username);
 
+    /* Connect to K2PG cluster. */
+	K2PgInitPostgresBackend("postgres", dbname, username);
+
     /*
      * PostgresMain thread can be user for wal sender, which will call
      * DataSenderMain() or WalSenderMain() later.
@@ -7318,9 +7321,6 @@ int PostgresMain(int argc, char* argv[], const char* dbname, const char* usernam
         t_thrd.proc_cxt.PostInit->InitWAL();
     else
         t_thrd.proc_cxt.PostInit->InitBackendWorker();
-
-    /* Connect to K2PG cluster. */
-	K2PgInitPostgresBackend("postgres", dbname, username);
 
     /*
      * If the t_thrd.mem_cxt.postmaster_mem_cxt is still around, recycle the space; we don't


### PR DESCRIPTION
1)  skip hot-chain procssing for k2 index build scan
2) skip toast declaration when generating bki file
3) disable RelationMapInitializePhase2 in RelationCacheInitializePhase2 for k2pg mode
4) move K2PgInitPostgresBackend before t_thrd.proc_cxt.PostInit->InitBackendWorker() so that k2pg gate is initialized before the PG initialization