### PR TITLE
Enable pg_hba.conf file creation and other fixes

### DIFF
--- a/src/common/backend/utils/cache/relcache.cpp
+++ b/src/common/backend/utils/cache/relcache.cpp
@@ -2363,10 +2363,16 @@ RelationInitBucketKey(Relation relation, HeapTuple tuple)
 static void RelationInitPhysicalAddr(Relation relation)
 {
     relation->rd_node.spcNode = ConvertToRelfilenodeTblspcOid(relation->rd_rel->reltablespace);
-    if (relation->rd_node.spcNode == GLOBALTABLESPACE_OID)
+    if (relation->rd_node.spcNode == GLOBALTABLESPACE_OID) {
         relation->rd_node.dbNode = InvalidOid;
-    else
+    } else {
         relation->rd_node.dbNode = u_sess->proc_cxt.MyDatabaseId;
+    }
+
+	if (!IsBootstrapProcessingMode() && IsK2PgRelation(relation)) {
+	  return;
+    }
+
     if (relation->rd_rel->relfilenode) {
         /*
          * Even if we are using a decoding snapshot that doesn't represent

--- a/src/common/backend/utils/resowner/resowner.cpp
+++ b/src/common/backend/utils/resowner/resowner.cpp
@@ -1416,11 +1416,13 @@ void ResourceOwnerForgetFakerelRef(ResourceOwner owner, Relation fakerel)
         return;
     }
 
-    ereport(ERROR,
-        (errcode(ERRCODE_WARNING_PRIVILEGE_NOT_GRANTED),
-            errmsg("fakerel reference %s is not owned by resource owner %s",
-                RelationGetRelationName(fakerel),
-                owner->name)));
+    elog(WARNING, "fakerel reference %s is not owned by resource owner %s", RelationGetRelationName(fakerel), owner->name);
+
+    // ereport(ERROR,
+    //     (errcode(ERRCODE_WARNING_PRIVILEGE_NOT_GRANTED),
+    //         errmsg("fakerel reference %s is not owned by resource owner %s",
+    //             RelationGetRelationName(fakerel),
+    //             owner->name)));
 }
 
 void ResourceOwnerEnlargeFakepartRefs(ResourceOwner owner)

--- a/src/gausskernel/storage/access/k2/k2pg_aux.cpp
+++ b/src/gausskernel/storage/access/k2/k2pg_aux.cpp
@@ -21,8 +21,6 @@ uint64_t k2pg_catalog_cache_version = K2PG_CATCACHE_VERSION_UNINITIALIZED;
 int k2pg_pg_double_write = -1;
 int k2pg_disable_pg_locking = -1;
 
-/* Forward declarations */
-static void K2PgInstallTxnDdlHook();
 
 bool
 IsK2PgEnabled()
@@ -272,7 +270,6 @@ K2PgInitPostgresBackend(
 	if (K2PgIsEnabledInPostgresEnvVar())
 	{
 		PgGate_InitPgGate();
-		K2PgInstallTxnDdlHook();
 
 		/*
 		 * For each process, we create one K2PG session for PostgreSQL to use
@@ -780,54 +777,6 @@ static void K2PgTxnDdlProcessUtility(
 		K2PgDecrementDdlNestingLevel(/* success */ true);
 	}
 
-}
-
-// static void K2PgTxnDdlProcessUtility(
-// 		PlannedStmt *pstmt,
-// 		const char *queryString,
-// 		ProcessUtilityContext context,
-// 		ParamListInfo params,
-// 		QueryEnvironment *queryEnv,
-// 		DestReceiver *dest,
-// 		char *completionTag) {
-// 	Node	   *parsetree = pstmt->utilityStmt;
-// 	NodeTag node_tag = nodeTag(parsetree);
-
-// 	bool is_txn_ddl = IsTransactionalDdlStatement(node_tag);
-
-// 	if (is_txn_ddl) {
-// 		K2PgIncrementDdlNestingLevel();
-// 	}
-// 	PG_TRY();
-// 	{
-// 		if (prev_ProcessUtility)
-// 			prev_ProcessUtility(pstmt, queryString,
-// 								context, params, queryEnv,
-// 								dest, completionTag);
-// 		else
-// 			standard_ProcessUtility(pstmt, queryString,
-// 									context, params, queryEnv,
-// 									dest, completionTag);
-// 	}
-// 	PG_CATCH();
-// 	{
-// 		if (is_txn_ddl) {
-// 			K2PgDecrementDdlNestingLevel(/* success */ false);
-// 		}
-// 		PG_RE_THROW();
-// 	}
-// 	PG_END_TRY();
-// 	if (is_txn_ddl) {
-// 		K2PgDecrementDdlNestingLevel(/* success */ true);
-// 	}
-// }
-
-
-static void K2PgInstallTxnDdlHook() {
-	if (!K2PgIsInitDbModeEnvVarSet()) {
-		prev_ProcessUtility = ProcessUtility_hook;
-		ProcessUtility_hook = K2PgTxnDdlProcessUtility;
-	}
 }
 
 bool

--- a/src/gausskernel/storage/access/k2/pg_gate_api.cpp
+++ b/src/gausskernel/storage/access/k2/pg_gate_api.cpp
@@ -1231,13 +1231,3 @@ void K2PgAssignTransactionPriorityLowerBound(double newval, void* extra) {
 void K2PgAssignTransactionPriorityUpperBound(double newval, void* extra) {
   elog(LOG, "PgGateAPI: K2PgAssignTransactionPriorityUpperBound %f", newval);
 }
-
-// the following APIs are called by pg_dump.c only
-// TODO: check if we really need to implement them
-
-K2PgStatus PgGate_InitPgGateBackend() {
-  return K2PgStatus::OK;
-}
-
-void PgGate_ShutdownPgGateBackend() {
-}

--- a/src/include/access/k2/pg_gate_api.h
+++ b/src/include/access/k2/pg_gate_api.h
@@ -359,8 +359,3 @@ void* PgGate_GetThreadLocalJumpBuffer();
 void PgGate_SetThreadLocalErrMsg(const void* new_msg);
 
 const void* PgGate_GetThreadLocalErrMsg();
-
-// APIs called by pg_dump.c only
-void PgGate_ShutdownPgGateBackend();
-
-K2PgStatus PgGate_InitPgGateBackend();


### PR DESCRIPTION
1) skip RelationInitPhysicalAddr for k2pg in non-bootstrap mode
2) change ResourceOwnerForgetFakerelRef error to warning temporarily, will fix them when refactoring memory context later
3) allow the creation of pg_hba.conf, which is required for gaussdb startup
4) fix warning on if else statements
5) remove unneeded K2PgInstallTxnDdlHook from k2pg_aux
6) fix output message format in initdb