### PR TITLE
pass is_shared_table flag down to PgGate APIs

### DIFF
--- a/simpleInstall/install.sh
+++ b/simpleInstall/install.sh
@@ -214,7 +214,7 @@ function set_environment() {
 
 function single_install() {
     info "[step 6]: init datanode"
-    gs_initdb -w $password -D $app/data/single_node --debug --nodename "sgnode" --locale="en_US.UTF-8"
+    gs_initdb -w $password -D $app/data/single_node --debug --noclean --nodename "sgnode" --locale="en_US.UTF-8"
     if [ X$port != X$default_port  ]
     then
         sed -i "/^#port =/c\port = $port" $app/data/single_node/postgresql.conf

--- a/src/gausskernel/optimizer/commands/dbcommands.cpp
+++ b/src/gausskernel/optimizer/commands/dbcommands.cpp
@@ -186,6 +186,10 @@ void createdb(const CreatedbStmt* stmt)
     createdb_failure_params fparms;
     Snapshot snapshot;
 
+    if (dbname != NULL && (strcmp(dbname, "template0") == 0 || strcmp(dbname, "template1") == 0)) {
+        K2PgSetPreparingTemplates();
+    }
+
     /* Extract options from the statement node tree */
     foreach (option, stmt->options) {
         DefElem* defel = (DefElem*)lfirst(option);

--- a/src/gausskernel/process/tcop/postgres.cpp
+++ b/src/gausskernel/process/tcop/postgres.cpp
@@ -7023,6 +7023,21 @@ void RemoveTempNamespace()
  */
 int PostgresMain(int argc, char* argv[], const char* dbname, const char* username)
 {
+    for (int i = 0; i < argc; i++) {
+        if (strcmp(argv[i], "template0") == 0 || strcmp(argv[i], "template1") == 0) {
+            K2PgSetPreparingTemplates();
+        }
+    }
+    if (dbname) {
+        if (strcmp(dbname, "template0") == 0 || strcmp(dbname, "template1") == 0) {
+            K2PgSetPreparingTemplates();
+        }
+    } else if (username) {
+        if (strcmp(username, "template0") == 0 || strcmp(username, "template1") == 0) {
+            K2PgSetPreparingTemplates();
+        }
+    }
+
     int firstchar;
     StringInfoData input_message = {NULL, 0, 0, 0};
     sigjmp_buf local_sigjmp_buf;

--- a/src/gausskernel/storage/access/k2/k2_bootstrap.cpp
+++ b/src/gausskernel/storage/access/k2/k2_bootstrap.cpp
@@ -141,7 +141,8 @@ void K2PgCreateSysCatalogTable(const char *table_name,
 	                                   table_name,
 	                                   TemplateDbOid,
 	                                   table_oid,
+					     is_shared_relation,
 	                                   false, /* if_not_exists */
-									   pkey_idx == NULL, /* add_primary_key */
+					     pkey_idx == NULL, /* add_primary_key */
 	                                   columns));
 }

--- a/src/gausskernel/storage/access/k2/k2cat_cmds.cpp
+++ b/src/gausskernel/storage/access/k2/k2cat_cmds.cpp
@@ -261,6 +261,7 @@ K2PgCreateTable(CreateStmt *stmt, char relkind, TupleDesc desc, Oid relationId, 
 									   stmt->relation->relname,
 									   u_sess->proc_cxt.MyDatabaseId,
 									   relationId,
+									   false, /* is_shared_table */
 									   false, /* if_not_exists */
 									   primary_key == NULL /* add_primary_key */,
 									   columns));

--- a/src/gausskernel/storage/access/k2/pg_gate_api.cpp
+++ b/src/gausskernel/storage/access/k2/pg_gate_api.cpp
@@ -320,16 +320,18 @@ K2PgStatus PgGate_ExecCreateTable(const char *database_name,
                               const char *table_name,
                               K2PgOid database_oid,
                               K2PgOid table_oid,
+                              bool is_shared_table,
                               bool if_not_exist,
                               bool add_primary_key,
                               const std::vector<K2PGColumnDef>& columns) {
-    elog(LOG, "PgGateAPI: PgGate_NewCreateTable %s, %s, %s", database_name, schema_name, table_name);
+    elog(LOG, "PgGateAPI: PgGate_NewCreateTable %s, %s, %s, shared: %d, if_not_exist: %d, add_primary_key: %d", database_name, schema_name, table_name,
+        is_shared_table, if_not_exist, add_primary_key);
     auto [status, is_pg_catalog_table, schema] = makeSchema(schema_name, columns, add_primary_key);
     if (!status.IsOK()) {
         return status;
     }
     const k2pg::PgObjectId table_object_id(database_oid, table_oid);
-    return pg_gate->GetCatalogClient()->CreateTable(database_name, table_name, table_object_id, schema, is_pg_catalog_table, false /* is_shared_table */, if_not_exist);
+    return pg_gate->GetCatalogClient()->CreateTable(database_name, table_name, table_object_id, schema, is_pg_catalog_table, is_shared_table, if_not_exist);
 }
 
 K2PgStatus PgGate_NewAlterTable(K2PgOid database_oid,

--- a/src/include/access/k2/pg_gate_api.h
+++ b/src/include/access/k2/pg_gate_api.h
@@ -124,6 +124,7 @@ K2PgStatus PgGate_ExecCreateTable(const char *database_name,
                               const char *table_name,
                               K2PgOid database_oid,
                               K2PgOid table_oid,
+                              bool is_shared_relation,
                               bool if_not_exist,
                               bool add_primary_key,
                               const std::vector<K2PGColumnDef>& columns);


### PR DESCRIPTION
1) Pass is_shared_table flag for system table creation, otherwise, the table content isn't correct. For example, pg_database will not be able to show all databases in the whole database.
2) add --noclean flag to gs_initdb in install.sh so that we could look at PG logs after the process exits.
3) add missing K2PgSetPreparingTemplates() calls, thanks for Ivan's good catch
4) remove unneeded K2PgTxnDdlProcessUtility() in k2pg_aux