### PR TITLE
K2PgPreloadRelCache fix and k2tupleid as constraint fix

### DIFF
--- a/src/gausskernel/storage/access/k2/storage.cpp
+++ b/src/gausskernel/storage/access/k2/storage.cpp
@@ -593,8 +593,8 @@ skv::http::dto::expression::Expression buildScanExpr(K2PgScanHandle* scan, const
 
     auto it = attr_to_offset.find(constraint.attr_num);
     if (it == attr_to_offset.end()) {
-        K2LOG_W(log::k2pg, "Attr_num not found in map for buildScanExpr: {}", constraint.attr_num);
-        return opr_expr;
+        K2LOG_W(log::k2pg, "Attr_num not found in map for buildScanExpr: {}, constants size {}", constraint.attr_num, constraint.constants.size());
+        return expression::Expression();
     }
     uint32_t offset = it->second;
 


### PR DESCRIPTION
K2PgPreloadRelCache expected the results from k2 to be in order, which is not the case for chogori-opengauss. This fix sorts things after the scan so they can be processed into the relation cache.

Also quick workaround for k2tupleid as a scan constraint attribute. It will not throw an error anymore but will result in a full scan.