### PR TITLE
Resource owner fix

### DIFF
--- a/src/common/backend/catalog/pg_depend.cpp
+++ b/src/common/backend/catalog/pg_depend.cpp
@@ -104,7 +104,7 @@ void recordMultipleDependencies(
 
             tup = heap_form_tuple(dependDesc->rd_att, values, nulls);
 
-            (void)simple_heap_insert(dependDesc, tup);
+            (void)CatalogTupleInsert(dependDesc, tup);
 
             /* keep indexes current */
             if (indstate == NULL)
@@ -212,7 +212,7 @@ void recordPinnedDependency(const ObjectAddress* object)
 
     tup = heap_form_tuple(dependDesc->rd_att, values, nulls);
 
-    (void)simple_heap_insert(dependDesc, tup);
+    (void)CatalogTupleInsert(dependDesc, tup);
 
     /* keep indexes current */
     if (indstate == NULL)

--- a/src/common/backend/catalog/pg_shdepend.cpp
+++ b/src/common/backend/catalog/pg_shdepend.cpp
@@ -274,7 +274,7 @@ static void shdepChangeDep(Relation sdepRel, Oid classid, Oid objid, int32 objsu
          * it's certainly a new tuple
          */
         oldtup = heap_form_tuple(RelationGetDescr(sdepRel), values, nulls);
-        (void)simple_heap_insert(sdepRel, oldtup);
+        (void)CatalogTupleInsert(sdepRel, oldtup);
 
         /* keep indexes current */
         CatalogUpdateIndexes(sdepRel, oldtup);
@@ -732,7 +732,7 @@ void copyTemplateDependencies(Oid templateDbId, Oid newDbId)
         HeapTuple newtup;
 
         newtup = heap_modify_tuple(tup, sdepDesc, values, nulls, replace);
-        (void)simple_heap_insert(sdepRel, newtup);
+        (void)CatalogTupleInsert(sdepRel, newtup);
 
         /* Keep indexes current */
         CatalogIndexInsert(indstate, newtup);
@@ -873,7 +873,7 @@ static void shdepAddDependency(Relation sdepRel, Oid classId, Oid objectId, int3
 
     tup = heap_form_tuple(sdepRel->rd_att, values, nulls);
 
-    (void)simple_heap_insert(sdepRel, tup);
+    (void)CatalogTupleInsert(sdepRel, tup);
 
     /* keep indexes current */
     CatalogUpdateIndexes(sdepRel, tup);
@@ -1674,7 +1674,7 @@ void changeDependencyOnObjfile(Oid objectId, Oid refobjId, const char* newObjfil
             values[Anum_pg_shdepend_objfile - 1] = CStringGetTextDatum(newObjfile);
 
             newtup = heap_form_tuple(sdepRel->rd_att, values, nulls);
-            (void)simple_heap_insert(sdepRel, newtup);
+            (void)CatalogTupleInsert(sdepRel, newtup);
 
             /* keep indexes current */
             CatalogUpdateIndexes(sdepRel, newtup);

--- a/src/common/backend/utils/resowner/resowner.cpp
+++ b/src/common/backend/utils/resowner/resowner.cpp
@@ -37,51 +37,6 @@
 #include "catalog/pg_hashbucket_fn.h"
 
 /*
- * ResourceArray is a common structure for storing all types of resource IDs.
- *
- * We manage small sets of resource IDs by keeping them in a simple array:
- * itemsarr[k] holds an ID, for 0 <= k < nitems <= maxitems = capacity.
- *
- * If a set grows large, we switch over to using open-addressing hashing.
- * Then, itemsarr[] is a hash table of "capacity" slots, with each
- * slot holding either an ID or "invalidval".  nitems is the number of valid
- * items present; if it would exceed maxitems, we enlarge the array and
- * re-hash.  In this mode, maxitems should be rather less than capacity so
- * that we don't waste too much time searching for empty slots.
- *
- * In either mode, lastidx remembers the location of the last item inserted
- * or returned by GetAny; this speeds up searches in ResourceArrayRemove.
- */
-typedef struct ResourceArray
-{
-	Datum	   *itemsarr;		/* buffer for storing values */
-	Datum		invalidval;		/* value that is considered invalid */
-	uint32		capacity;		/* allocated length of itemsarr[] */
-	uint32		nitems;			/* how many items are stored in items array */
-	uint32		maxitems;		/* current limit on nitems before enlarging */
-	uint32		lastidx;		/* index of last item returned by GetAny */
-} ResourceArray;
-
-/*
- * Initially allocated size of a ResourceArray.  Must be power of two since
- * we'll use (arraysize - 1) as mask for hashing.
- */
-#define RESARRAY_INIT_SIZE 16
-
-/*
- * When to switch to hashing vs. simple array logic in a ResourceArray.
- */
-#define RESARRAY_MAX_ARRAY 64
-#define RESARRAY_IS_ARRAY(resarr) ((resarr)->capacity <= RESARRAY_MAX_ARRAY)
-
-/*
- * How many items may be stored in a resource array of given capacity.
- * When this number is reached, we must resize.
- */
-#define RESARRAY_MAX_ITEMS(capacity) \
-	((capacity) <= RESARRAY_MAX_ARRAY ? (capacity) : (capacity)/4 * 3)
-
-/*
  * ResourceOwner objects look like this
  */
 typedef struct ResourceOwnerData {
@@ -167,8 +122,6 @@ typedef struct ResourceOwnerData {
     int maxGlobalMemContexts;
 
     MemoryContext memCxt;
-
-    ResourceArray k2stmtarr;    /* K2PG statement handles */
 } ResourceOwnerData;
 
 THR_LOCAL ResourceOwner IsolatedResourceOwner = NULL;
@@ -183,12 +136,6 @@ typedef struct ResourceReleaseCallbackItem {
 } ResourceReleaseCallbackItem;
 
 /* Internal routines */
-static void ResourceArrayInit(ResourceArray *resarr, Datum invalidval);
-static void ResourceArrayEnlarge(ResourceArray *resarr);
-static void ResourceArrayAdd(ResourceArray *resarr, Datum value);
-static bool ResourceArrayRemove(ResourceArray *resarr, Datum value);
-static bool ResourceArrayGetAny(ResourceArray *resarr, Datum *value);
-static void ResourceArrayFree(ResourceArray *resarr);
 
 static void ResourceOwnerReleaseInternal(
     ResourceOwner owner, ResourceReleasePhase phase, bool isCommit, bool isTopLevel);
@@ -204,229 +151,6 @@ static void PrintFileLeakWarning(File file);
 extern void PrintMetaCacheBlockLeakWarning(CacheSlotId_t slot);
 
 extern void ReleaseMetaBlock(CacheSlotId_t slot);
-
-/*
- * Initialize a ResourceArray
- */
-static void
-ResourceArrayInit(ResourceArray *resarr, Datum invalidval)
-{
-	/* Assert it's empty */
-	Assert(resarr->itemsarr == NULL);
-	Assert(resarr->capacity == 0);
-	Assert(resarr->nitems == 0);
-	Assert(resarr->maxitems == 0);
-	/* Remember the appropriate "invalid" value */
-	resarr->invalidval = invalidval;
-	/* We don't allocate any storage until needed */
-}
-
-/*
- * Make sure there is room for at least one more resource in an array.
- *
- * This is separate from actually inserting a resource because if we run out
- * of memory, it's critical to do so *before* acquiring the resource.
- */
-static void
-ResourceArrayEnlarge(ResourceArray *resarr)
-{
-	uint32		i,
-				oldcap,
-				newcap;
-	Datum	   *olditemsarr;
-	Datum	   *newitemsarr;
-
-	if (resarr->nitems < resarr->maxitems)
-		return;					/* no work needed */
-
-	olditemsarr = resarr->itemsarr;
-	oldcap = resarr->capacity;
-
-	/* Double the capacity of the array (capacity must stay a power of 2!) */
-	newcap = (oldcap > 0) ? oldcap * 2 : RESARRAY_INIT_SIZE;
-	newitemsarr = (Datum *) MemoryContextAlloc(t_thrd.mem_cxt.cur_transaction_mem_cxt,
-											   newcap * sizeof(Datum));
-	for (i = 0; i < newcap; i++)
-		newitemsarr[i] = resarr->invalidval;
-
-	/* We assume we can't fail below this point, so OK to scribble on resarr */
-	resarr->itemsarr = newitemsarr;
-	resarr->capacity = newcap;
-	resarr->maxitems = RESARRAY_MAX_ITEMS(newcap);
-	resarr->nitems = 0;
-
-	if (olditemsarr != NULL)
-	{
-		/*
-		 * Transfer any pre-existing entries into the new array; they don't
-		 * necessarily go where they were before, so this simple logic is the
-		 * best way.  Note that if we were managing the set as a simple array,
-		 * the entries after nitems are garbage, but that shouldn't matter
-		 * because we won't get here unless nitems was equal to oldcap.
-		 */
-		for (i = 0; i < oldcap; i++)
-		{
-			if (olditemsarr[i] != resarr->invalidval)
-				ResourceArrayAdd(resarr, olditemsarr[i]);
-		}
-
-		/* And release old array. */
-		pfree(olditemsarr);
-	}
-
-	Assert(resarr->nitems < resarr->maxitems);
-}
-
-/*
- * Add a resource to ResourceArray
- *
- * Caller must have previously done ResourceArrayEnlarge()
- */
-static void
-ResourceArrayAdd(ResourceArray *resarr, Datum value)
-{
-	uint32		idx;
-
-	Assert(value != resarr->invalidval);
-	Assert(resarr->nitems < resarr->maxitems);
-
-	if (RESARRAY_IS_ARRAY(resarr))
-	{
-		/* Append to linear array. */
-		idx = resarr->nitems;
-	}
-	else
-	{
-		/* Insert into first free slot at or after hash location. */
-		uint32		mask = resarr->capacity - 1;
-
-        idx = DatumGetUInt32(hash_any((const unsigned char*) &value, sizeof(value))) & mask;
-		for (;;)
-		{
-			if (resarr->itemsarr[idx] == resarr->invalidval)
-				break;
-			idx = (idx + 1) & mask;
-		}
-	}
-	resarr->lastidx = idx;
-	resarr->itemsarr[idx] = value;
-	resarr->nitems++;
-}
-
-/*
- * Remove a resource from ResourceArray
- *
- * Returns true on success, false if resource was not found.
- *
- * Note: if same resource ID appears more than once, one instance is removed.
- */
-static bool
-ResourceArrayRemove(ResourceArray *resarr, Datum value)
-{
-	uint32		i,
-				idx,
-				lastidx = resarr->lastidx;
-
-	Assert(value != resarr->invalidval);
-
-	/* Search through all items, but try lastidx first. */
-	if (RESARRAY_IS_ARRAY(resarr))
-	{
-		if (lastidx < resarr->nitems &&
-			resarr->itemsarr[lastidx] == value)
-		{
-			resarr->itemsarr[lastidx] = resarr->itemsarr[resarr->nitems - 1];
-			resarr->nitems--;
-			/* Update lastidx to make reverse-order removals fast. */
-			resarr->lastidx = resarr->nitems - 1;
-			return true;
-		}
-		for (i = 0; i < resarr->nitems; i++)
-		{
-			if (resarr->itemsarr[i] == value)
-			{
-				resarr->itemsarr[i] = resarr->itemsarr[resarr->nitems - 1];
-				resarr->nitems--;
-				/* Update lastidx to make reverse-order removals fast. */
-				resarr->lastidx = resarr->nitems - 1;
-				return true;
-			}
-		}
-	}
-	else
-	{
-		uint32		mask = resarr->capacity - 1;
-
-		if (lastidx < resarr->capacity &&
-			resarr->itemsarr[lastidx] == value)
-		{
-			resarr->itemsarr[lastidx] = resarr->invalidval;
-			resarr->nitems--;
-			return true;
-		}
-		idx = DatumGetUInt32(hash_any((const unsigned char*) &value, sizeof(value))) & mask;
-		for (i = 0; i < resarr->capacity; i++)
-		{
-			if (resarr->itemsarr[idx] == value)
-			{
-				resarr->itemsarr[idx] = resarr->invalidval;
-				resarr->nitems--;
-				return true;
-			}
-			idx = (idx + 1) & mask;
-		}
-	}
-
-	return false;
-}
-
-/*
- * Get any convenient entry in a ResourceArray.
- *
- * "Convenient" is defined as "easy for ResourceArrayRemove to remove";
- * we help that along by setting lastidx to match.  This avoids O(N^2) cost
- * when removing all ResourceArray items during ResourceOwner destruction.
- *
- * Returns true if we found an element, or false if the array is empty.
- */
-static bool
-ResourceArrayGetAny(ResourceArray *resarr, Datum *value)
-{
-	if (resarr->nitems == 0)
-		return false;
-
-	if (RESARRAY_IS_ARRAY(resarr))
-	{
-		/* Linear array: just return the first element. */
-		resarr->lastidx = 0;
-	}
-	else
-	{
-		/* Hash: search forward from wherever we were last. */
-		uint32		mask = resarr->capacity - 1;
-
-		for (;;)
-		{
-			resarr->lastidx &= mask;
-			if (resarr->itemsarr[resarr->lastidx] != resarr->invalidval)
-				break;
-			resarr->lastidx++;
-		}
-	}
-
-	*value = resarr->itemsarr[resarr->lastidx];
-	return true;
-}
-
-/*
- * Trash a ResourceArray (we don't care about its state after this)
- */
-static void
-ResourceArrayFree(ResourceArray *resarr)
-{
-	if (resarr->itemsarr)
-		pfree(resarr->itemsarr);
-}
 
 /*****************************************************************************
  *	  EXPORTED ROUTINES														 *
@@ -454,10 +178,6 @@ ResourceOwner ResourceOwnerCreate(ResourceOwner parent, const char* name, Memory
 
     if (parent == NULL && strcmp(name, "TopTransaction") != 0) {
         IsolatedResourceOwner = owner;
-    }
-
-	if (IsK2Mode()) {
-		ResourceArrayInit(&(owner->k2stmtarr), PointerGetDatum(NULL));
     }
 
     return owner;
@@ -759,7 +479,6 @@ void ResourceOwnerDelete(ResourceOwner owner)
     Assert(owner->nDataCacheSlots == 0);
     Assert(owner->nMetaCacheSlots == 0);
     Assert(owner->nPthreadMutex == 0);
-	Assert(owner->k2stmtarr.nitems == 0);
 
     /*
      * Delete children.  The recursive call will delink the child from me, so
@@ -777,8 +496,6 @@ void ResourceOwnerDelete(ResourceOwner owner)
      * the owner tree.	Better a leak than a crash.
      */
     ResourceOwnerNewParent(owner, NULL);
-
-	ResourceArrayFree(&(owner->k2stmtarr));
 
     if (owner == t_thrd.utils_cxt.STPSavedResourceOwner) {
         return;

--- a/src/gausskernel/optimizer/commands/comment.cpp
+++ b/src/gausskernel/optimizer/commands/comment.cpp
@@ -160,7 +160,7 @@ void CommentObject(CommentStmt* stmt)
              * failures.
              */
             if (relation != NULL) {
-                if (relation->rd_rel->relkind != RELKIND_RELATION && 
+                if (relation->rd_rel->relkind != RELKIND_RELATION &&
                     relation->rd_rel->relkind != RELKIND_VIEW &&
                     relation->rd_rel->relkind != RELKIND_CONTQUERY &&
                     relation->rd_rel->relkind != RELKIND_MATVIEW &&
@@ -260,7 +260,7 @@ void CreateComments(Oid oid, Oid classoid, int32 subid, const char* comment)
     /* If we didn't find an old tuple, insert a new one */
     if (newtuple == NULL && comment != NULL) {
         newtuple = heap_form_tuple(RelationGetDescr(description), values, nulls);
-        (void)simple_heap_insert(description, newtuple);
+        (void)CatalogTupleInsert(description, newtuple);
     }
 
     /* Update indexes, if necessary */
@@ -331,7 +331,7 @@ void CreateSharedComments(Oid oid, Oid classoid, const char* comment)
     /* If we didn't find an old tuple, insert a new one */
     if (newtuple == NULL && comment != NULL) {
         newtuple = heap_form_tuple(RelationGetDescr(shdescription), values, nulls);
-        (void)simple_heap_insert(shdescription, newtuple);
+        (void)CatalogTupleInsert(shdescription, newtuple);
     }
 
     /* Update indexes, if necessary */

--- a/src/gausskernel/optimizer/commands/extension.cpp
+++ b/src/gausskernel/optimizer/commands/extension.cpp
@@ -1194,11 +1194,11 @@ void CreateExtension(CreateExtensionStmt* stmt)
                     errmsg("extension \"%s\" already exists in schema \"%s\", skipping", stmt->extname, schemaName)));
             return;
         } else {
-#ifndef ENABLE_MULTIPLE_NODES		
+#ifndef ENABLE_MULTIPLE_NODES
             ereport(ERROR,
                 (errcode(ERRCODE_DUPLICATE_OBJECT),
                     errmsg("extension \"%s\" already exists in schema \"%s\"", stmt->extname, schemaName)));
-#else					
+#else
             /*
              * Currently extension only support postgis.
              */
@@ -1208,7 +1208,7 @@ void CreateExtension(CreateExtensionStmt* stmt)
                         errmsg("extension \"%s\" already exists in schema \"%s\"", stmt->extname, schemaName)));
             else
                 FEATURE_NOT_PUBLIC_ERROR("EXTENSION is not yet supported.");
-#endif				
+#endif
         }
     }
 
@@ -1501,7 +1501,7 @@ Oid InsertExtensionTuple(const char* extName, Oid extOwner, Oid schemaOid, bool 
 
     tuple = heap_form_tuple(rel->rd_att, values, nulls);
 
-    extensionOid = simple_heap_insert(rel, tuple);
+    extensionOid = CatalogTupleInsert(rel, tuple);
     CatalogUpdateIndexes(rel, tuple);
 
     tableam_tops_free_tuple(tuple);
@@ -2896,7 +2896,7 @@ void AlterExtensionOwner_oid(Oid extensionOid, Oid newOwnerId)
     heap_close(rel, NoLock);
 }
 
-/* 
+/*
  * Expand the size of extension_session_vars_array_size by twice the number
  * of extensions each time if latter is bigger.
  */

--- a/src/gausskernel/storage/access/k2/k2pg_aux.cpp
+++ b/src/gausskernel/storage/access/k2/k2pg_aux.cpp
@@ -205,21 +205,6 @@ HandleK2PgStatusIgnoreNotFound(const K2PgStatus& status, bool *not_found)
 }
 
 void
-HandleK2PgStatusWithOwner(const K2PgStatus& status,
-												K2PgScanHandle* k2pg_stmt,
-												ResourceOwner owner)
-{
-	if (k2pg_stmt)
-	{
-		if (owner != NULL)
-		{
-			ResourceOwnerForgetK2PgStmt(owner, k2pg_stmt);
-		}
-	}
-	HandleK2PgStatus(status);
-}
-
-void
 HandleK2PgTableDescStatus(const K2PgStatus& status, K2PgTableDesc table)
 {
 	HandleK2PgStatus(status);

--- a/src/gausskernel/storage/k2/fdw_handlers.cpp
+++ b/src/gausskernel/storage/k2/fdw_handlers.cpp
@@ -58,6 +58,7 @@ Copyright(c) 2022 Futurewei Cloud
 #include "utils/date.h"
 #include "utils/syscache.h"
 #include "utils/partitionkey.h"
+#include "utils/palloc.h"
 #include "catalog/heap.h"
 #include "optimizer/var.h"
 #include "optimizer/clauses.h"
@@ -92,7 +93,7 @@ struct K2FdwPushDownState {
 
 struct K2FdwExecState {
     /* The handle for the internal K2PG Select statement. */
-    ResourceOwner stmt_owner{0};
+    MemoryContext k2_ctx;
 
     // parameters required for call to ExecSelect
     std::vector<K2PgConstraintDef> constraints;
@@ -327,9 +328,11 @@ k2BeginForeignScan(ForeignScanState *node, int eflags)
 
 
     /* Allocate and initialize K2PG scan state. */
-    K2FdwExecState *k2pg_state = new K2FdwExecState();
-    GetCurrentK2Memctx()->Cache([ptr = k2pg_state]() { delete ptr; });
+	K2FdwExecState *k2pg_state = (K2FdwExecState *) palloc0(sizeof(K2FdwExecState));
+
     node->fdw_state = (void *)k2pg_state;
+    k2pg_state->k2_ctx = AllocSetContextCreate(node->scanMcxt, "k2 FDW scan context",
+        ALLOCSET_SMALL_MINSIZE, ALLOCSET_SMALL_INITSIZE, ALLOCSET_SMALL_MAXSIZE);
 
     ListCell *lc{0};
     // go over the target attribute numbers we stored before in the fdw_private
@@ -376,19 +379,20 @@ k2BeginForeignScan(ForeignScanState *node, int eflags)
     k2pg_state->limit_params.limit_offset = 0;    // TODO the value of SELECT ... OFFSET
     k2pg_state->limit_params.limit_use_default = true;
 
+    /* switch MemoryContext */
+    MemoryContext oldcontext = MemoryContextSwitchTo(k2pg_state->k2_ctx);
+
     HandleK2PgStatus(PgGate_NewSelect(K2PgGetDatabaseOid(relation), RelationGetRelid(relation),
                                       std::move(index_params), &k2pg_state->k2_handle));
-    ResourceOwnerEnlargeK2PgStmts(t_thrd.utils_cxt.CurrentResourceOwner);
-    ResourceOwnerRememberK2PgStmt(t_thrd.utils_cxt.CurrentResourceOwner, k2pg_state->k2_handle);
-    k2pg_state->stmt_owner = t_thrd.utils_cxt.CurrentResourceOwner;
 
     // TODO Add this back when we consolidate PGStatement and K2PGScanHandle
     /* Set the current syscatalog version (will check that we are up to date) */
-    // HandleK2PgStatusWithOwner(PgGate_SetCatalogCacheVersion(k2pg_state->k2_handle,
-    //                                                    k2pg_catalog_cache_version),
-    //                                                    k2pg_state->k2_handle,
-    //                                                    k2pg_state->stmt_owner);
+    // HandleK2PgStatus(PgGate_SetCatalogCacheVersion(k2pg_state->k2_handle,
+    //                                                    k2pg_catalog_cache_version));
     K2LOG_D(log::fdw, "foreign_scan for relation {}, fdw_exprs: {}", relation->rd_id, list_length(foreignScan->fdw_exprs));
+
+   /* release memory */
+    (void)MemoryContextSwitchTo(oldcontext);
 
     K2LOG_D(log::fdw, "BeginForeignScan done");
 }
@@ -406,6 +410,8 @@ k2IterateForeignScan(ForeignScanState *node)
     K2FdwExecState *k2pg_state = (K2FdwExecState *) node->fdw_state;
     Relation relation = node->ss.ss_currentRelation;
 
+    MemoryContext oldcontext = MemoryContextSwitchTo(k2pg_state->k2_ctx);
+
     HandleK2PgStatus(PgGate_ExecSelect(k2pg_state->k2_handle, k2pg_state->constraints,
                     k2pg_state->targets_attrnum, k2pg_state->forward_scan, k2pg_state->limit_params));
 
@@ -421,14 +427,12 @@ k2IterateForeignScan(ForeignScanState *node)
     Datum           *values = slot->tts_values;
     bool            *isnull = slot->tts_isnull;
     K2PgSysColumns    syscols;
-    HandleK2PgStatusWithOwner(PgGate_DmlFetch(k2pg_state->k2_handle,
+    HandleK2PgStatus(PgGate_DmlFetch(k2pg_state->k2_handle,
                                           tupdesc->natts,
                                           (uint64_t *) values,
                                           isnull,
                                           &syscols,
-                                          &has_data),
-                            k2pg_state->k2_handle,
-                            k2pg_state->stmt_owner);
+                                          &has_data));
 
     /* If we have result(s) update the tuple slot. */
     if (has_data) {
@@ -443,6 +447,8 @@ k2IterateForeignScan(ForeignScanState *node)
         slot->tts_k2pgctid = PointerGetDatum(syscols.k2pgctid);
     }
 
+    (void)MemoryContextSwitchTo(oldcontext);
+
     return slot;
 }
 
@@ -451,8 +457,14 @@ k2IterateForeignScan(ForeignScanState *node)
  */
 void k2EndForeignScan(ForeignScanState *node) {
     (void)node;
+
+    K2FdwExecState *k2pg_state = (K2FdwExecState *) node->fdw_state;
+	if (NULL != k2pg_state->k2_ctx && k2pg_state->k2_ctx != CurrentMemoryContext) {
+	    MemoryContextDelete(k2pg_state->k2_ctx);
+	}
+	pfree(k2pg_state);
+
     K2LOG_D(log::fdw, "End foreignscan called");
-    // TODO cleanup the query state on our side at end of query instead of at end of transaction
 }
 
 }  // namespace k2fdw

--- a/src/gausskernel/storage/k2/fdw_handlers.cpp
+++ b/src/gausskernel/storage/k2/fdw_handlers.cpp
@@ -328,7 +328,7 @@ k2BeginForeignScan(ForeignScanState *node, int eflags)
 
 
     /* Allocate and initialize K2PG scan state. */
-	K2FdwExecState *k2pg_state = (K2FdwExecState *) palloc0(sizeof(K2FdwExecState));
+	K2FdwExecState *k2pg_state = new K2FdwExecState();
 
     node->fdw_state = (void *)k2pg_state;
     k2pg_state->k2_ctx = AllocSetContextCreate(node->scanMcxt, "k2 FDW scan context",
@@ -456,13 +456,14 @@ k2IterateForeignScan(ForeignScanState *node)
  * Step 5. Done with scan
  */
 void k2EndForeignScan(ForeignScanState *node) {
-    (void)node;
-
     K2FdwExecState *k2pg_state = (K2FdwExecState *) node->fdw_state;
-	if (NULL != k2pg_state->k2_ctx && k2pg_state->k2_ctx != CurrentMemoryContext) {
-	    MemoryContextDelete(k2pg_state->k2_ctx);
-	}
-	pfree(k2pg_state);
+
+    if (k2pg_state != NULL) {
+	    if (NULL != k2pg_state->k2_ctx && k2pg_state->k2_ctx != CurrentMemoryContext) {
+	        MemoryContextDelete(k2pg_state->k2_ctx);
+	    }
+	    delete k2pg_state;
+    }
 
     K2LOG_D(log::fdw, "End foreignscan called");
 }

--- a/src/include/access/k2/k2catam.h
+++ b/src/include/access/k2/k2catam.h
@@ -36,6 +36,7 @@ Copyright(c) 2022 Futurewei Cloud
 #include "utils/relcache.h"
 #include "utils/resowner.h"
 #include "utils/snapshot.h"
+#include "utils/palloc.h"
 
 #include "access/k2/pg_gate_api.h"
 
@@ -48,8 +49,10 @@ typedef struct CamScanDescData
     // Data needed by PgGate for Exec call
     std::vector<K2PgConstraintDef> constraints;
     std::vector<int> targets_attrnum;
+	
+	// memory context for k2 scan operations
+	MemoryContext k2_ctx;
 
-	ResourceOwner stmt_owner;
 	bool is_exec_done;
 
 	Relation index;

--- a/src/include/utils/resowner.h
+++ b/src/include/utils/resowner.h
@@ -165,14 +165,4 @@ extern void ResourceOwnerRememberGMemContext(ResourceOwner owner, MemoryContext 
 extern void ResourceOwnerForgetGMemContext(ResourceOwner owner, MemoryContext memcontext);
 extern void PrintGMemContextLeakWarning(MemoryContext memcontext);
 
-/* support for K2PG statement refcount management */
-extern void ResourceOwnerEnlargeK2PgStmts(ResourceOwner owner);
-class K2PgScanHandle;
-extern void ResourceOwnerRememberK2PgStmt(
-	ResourceOwner owner,
-	K2PgScanHandle* k2pg_stmt);
-extern void ResourceOwnerForgetK2PgStmt(
-	ResourceOwner owner,
-	K2PgScanHandle* k2pg_stmt);
-
 #endif /* RESOWNER_H */


### PR DESCRIPTION
commit 4051e74761434f135da7a6f5fb8ff1f6dc59c00c (HEAD -> resource-owner-fix, origin/resource-owner-fix)
    change to use CatalogUpdateIndexes to insert extension and other related objects

commit a6dfdd6b7359b2eb99781e9a9581e522903b66e2
    remove backported resourceArray logic from PG 11

commit 6b0fab77e50f17b124b340a3684f1894748de27e
    attempt to replace resource owner logic with k2 memory context directly