### PR TITLE
remove memory context switch and add PgGate_ResetMemctx and PgGate_DestroyMemctx to mcxt

### DIFF
--- a/src/gausskernel/storage/access/k2/pg_memctx.cpp
+++ b/src/gausskernel/storage/access/k2/pg_memctx.cpp
@@ -57,7 +57,7 @@ PgMemctx *PgMemctx::Create() {
 
 Status PgMemctx::Destroy(PgMemctx *handle) {
   if (handle) {
-    if(postgres_process_memctxs.find(handle) != postgres_process_memctxs.end()) {
+    if(postgres_process_memctxs.find(handle) == postgres_process_memctxs.end()) {
         Status status {
             .pg_code = ERRCODE_INTERNAL_ERROR,
             .k2_code = 500,
@@ -75,7 +75,7 @@ Status PgMemctx::Destroy(PgMemctx *handle) {
 
 Status PgMemctx::Reset(PgMemctx *handle) {
   if (handle) {
-    if (postgres_process_memctxs.find(handle) != postgres_process_memctxs.end()) {
+    if (postgres_process_memctxs.find(handle) == postgres_process_memctxs.end()) {
         Status status {
             .pg_code = ERRCODE_INTERNAL_ERROR,
             .k2_code = 500,

--- a/src/gausskernel/storage/k2/fdw_handlers.cpp
+++ b/src/gausskernel/storage/k2/fdw_handlers.cpp
@@ -93,7 +93,6 @@ struct K2FdwPushDownState {
 
 struct K2FdwExecState {
     /* The handle for the internal K2PG Select statement. */
-    MemoryContext k2_ctx;
 
     // parameters required for call to ExecSelect
     std::vector<K2PgConstraintDef> constraints;
@@ -331,8 +330,6 @@ k2BeginForeignScan(ForeignScanState *node, int eflags)
 	K2FdwExecState *k2pg_state = new K2FdwExecState();
 
     node->fdw_state = (void *)k2pg_state;
-    k2pg_state->k2_ctx = AllocSetContextCreate(node->scanMcxt, "k2 FDW scan context",
-        ALLOCSET_SMALL_MINSIZE, ALLOCSET_SMALL_INITSIZE, ALLOCSET_SMALL_MAXSIZE);
 
     ListCell *lc{0};
     // go over the target attribute numbers we stored before in the fdw_private
@@ -379,9 +376,6 @@ k2BeginForeignScan(ForeignScanState *node, int eflags)
     k2pg_state->limit_params.limit_offset = 0;    // TODO the value of SELECT ... OFFSET
     k2pg_state->limit_params.limit_use_default = true;
 
-    /* switch MemoryContext */
-    MemoryContext oldcontext = MemoryContextSwitchTo(k2pg_state->k2_ctx);
-
     HandleK2PgStatus(PgGate_NewSelect(K2PgGetDatabaseOid(relation), RelationGetRelid(relation),
                                       std::move(index_params), &k2pg_state->k2_handle));
 
@@ -390,9 +384,6 @@ k2BeginForeignScan(ForeignScanState *node, int eflags)
     // HandleK2PgStatus(PgGate_SetCatalogCacheVersion(k2pg_state->k2_handle,
     //                                                    k2pg_catalog_cache_version));
     K2LOG_D(log::fdw, "foreign_scan for relation {}, fdw_exprs: {}", relation->rd_id, list_length(foreignScan->fdw_exprs));
-
-   /* release memory */
-    (void)MemoryContextSwitchTo(oldcontext);
 
     K2LOG_D(log::fdw, "BeginForeignScan done");
 }
@@ -409,8 +400,6 @@ k2IterateForeignScan(ForeignScanState *node)
     TupleTableSlot *slot= nullptr;
     K2FdwExecState *k2pg_state = (K2FdwExecState *) node->fdw_state;
     Relation relation = node->ss.ss_currentRelation;
-
-    MemoryContext oldcontext = MemoryContextSwitchTo(k2pg_state->k2_ctx);
 
     HandleK2PgStatus(PgGate_ExecSelect(k2pg_state->k2_handle, k2pg_state->constraints,
                     k2pg_state->targets_attrnum, k2pg_state->forward_scan, k2pg_state->limit_params));
@@ -447,8 +436,6 @@ k2IterateForeignScan(ForeignScanState *node)
         slot->tts_k2pgctid = PointerGetDatum(syscols.k2pgctid);
     }
 
-    (void)MemoryContextSwitchTo(oldcontext);
-
     return slot;
 }
 
@@ -457,11 +444,7 @@ k2IterateForeignScan(ForeignScanState *node)
  */
 void k2EndForeignScan(ForeignScanState *node) {
     K2FdwExecState *k2pg_state = (K2FdwExecState *) node->fdw_state;
-
     if (k2pg_state != NULL) {
-	    if (NULL != k2pg_state->k2_ctx && k2pg_state->k2_ctx != CurrentMemoryContext) {
-	        MemoryContextDelete(k2pg_state->k2_ctx);
-	    }
 	    delete k2pg_state;
     }
 


### PR DESCRIPTION
Tested:

2022-11-14 07:54:11.899 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  PgGateAPI: PgGate_FinishInitDB()
2022-11-14 07:54:11.910 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  PgGateAPI: PgGate_CommitTransaction
2022-11-14 07:54:11.915 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  shutting down
2022-11-14 07:54:11.980 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  will do full checkpoint, need flush 0 pages.
2022-11-14 07:54:11.980 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [SLRU] LOG:  remove old segments(<0) under pg_csnlog
2022-11-14 07:54:11.980 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  truncate CSN log oldestXact 4, next xid 359
2022-11-14 07:54:11.981 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [SLRU] LOG:  remove old segments(<0) under pg_multixact/offsets
2022-11-14 07:54:11.981 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [SLRU] LOG:  remove old segments(<0) under pg_multixact/members
2022-11-14 07:54:12.013 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [DBL_WRT] LOG:  [batch flush] DW truncate end: file_head[dwn 0, start 1], total_pages 0
2022-11-14 07:54:12.013 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [DBL_WRT] LOG:  [single flush] DW truncate end: file_head[dwn 1, start 0], total_pages 0
2022-11-14 07:54:12.016 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  keep all the xlog segments, because current segno = 1, less than wal_keep_segments = 16
2022-11-14 07:54:12.016 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  CreateCheckPoint PrintCkpXctlControlFile: [checkPoint] oldCkpLoc:0/1000028, oldRedo:0/1000028, newCkpLoc:0/10000A8, newRedo:0/10000A8, preCkpLoc:0/0
2022-11-14 07:54:12.016 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  will update control file (create checkpoint), shutdown:1
2022-11-14 07:54:12.081 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [DBL_WRT] LOG:  Double write exit
2022-11-14 07:54:12.081 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [DBL_WRT] LOG:  [single flush] DW truncate end: file_head[dwn 1, start 0], total_pages 0
2022-11-14 07:54:12.081 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [DBL_WRT] LOG:  Double write exit
2022-11-14 07:54:12.113 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [DBL_WRT] LOG:  [batch flush] DW truncate end: file_head[dwn 0, start 1], total_pages 0
2022-11-14 07:54:12.115 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  database system is shut down
2022-11-14 07:54:12.152 [unknown] [unknown] localhost 140523833519424 0[0:0#0]  [BACKEND] LOG:  FiniNuma allocIndex: 0.
k2pg_pclose_check exitstatus: 0
ok
Write version file base/1 ... 
Create PG default temp dir ... 
Setup auth ... 
initializing pg_authid ... 
"/opt/opengauss/bin/gaussdb" --single --localxid -F -O -c search_path=pg_catalog -c exit_on_error=true template1 >/dev/null 2>&1
k2pg_pclose_check exitstatus: 0
ok
get_set_pwd
setting password ... k2pg_pclose_check exitstatus: 0
ok
Setup depend,load plpgsql, and system views ... 
initializing dependencies ... k2pg_pclose_check exitstatus: 0
ok
loading PL/pgSQL server-side language ... k2pg_pclose_check exitstatus: 0
ok
creating system views ... k2pg_pclose_check exitstatus: 0
ok
Setup perf views ... 
creating performance views ... k2pg_pclose_check exitstatus: 0
ok
Setup description ... 
loading system objects' descriptions ... k2pg_pclose_check exitstatus: 0
ok
Setup collation ... 
creating collations ... k2pg_pclose_check exitstatus: 0
ok
Setup privileges ... 
setting privileges on built-in objects ... k2pg_pclose_check exitstatus: 0
ok
Setup bucketmap len ... 
initialize global configure for bucketmap length ... k2pg_pclose_check exitstatus: 0
ok
Setup schema ... 
creating information schema ... k2pg_pclose_check exitstatus: 0
k2pg_pclose_check exitstatus: 0
ok
Load supported extension ... 
loading foreign-data wrapper for distfs access ... k2pg_pclose_check exitstatus: 0
ok
loading foreign-data wrapper for hdfs access ... k2pg_pclose_check exitstatus: 0
ok
loading foreign-data wrapper for k2 access ... k2pg_pclose_check exitstatus: 0
ok
loading foreign-data wrapper for log access ... k2pg_pclose_check exitstatus: 0
ok
loading hstore extension ... k2pg_pclose_check exitstatus: 0
ok
loading foreign-data wrapper for MOT access ... k2pg_pclose_check exitstatus: 0
ok
loading security plugin ... k2pg_pclose_check exitstatus: 0
ok
Load update ... 
update system tables ... k2pg_pclose_check exitstatus: 0
ok
creating snapshots catalog ... k2pg_pclose_check exitstatus: 0
k2pg_pclose_check exitstatus: 0
k2pg_pclose_check exitstatus: 0
k2pg_pclose_check exitstatus: 0
k2pg_pclose_check exitstatus: 0
k2pg_pclose_check exitstatus: 0
ok
Make template0 ... 
copying template1 to template0 ... k2pg_pclose_check exitstatus: 0
ok
Make postgres ... 
copying template1 to postgres ... k2pg_pclose_check exitstatus: 0
ok
freezing database template0 ... k2pg_pclose_check exitstatus: 256
gs_initdb: data directory "/opt/opengauss/data/single_node" not removed at user's request
