### PR TITLE
skip relmap file check and disable job scheduler

### DIFF
--- a/src/bin/initdb/initdb.cpp
+++ b/src/bin/initdb/initdb.cpp
@@ -4551,11 +4551,18 @@ int main(int argc, char* argv[])
     setup_auth();
     get_set_pwd();
 
-    printf(_("Setup depend,load plpgsql, and system views ... \n"));
+    printf(_("Setup depend ... \n"));
     (void)fflush(stdout);
     setup_depend();
+
+    printf(_("Load plpgsql ... \n"));
+    (void)fflush(stdout);
     load_plpgsql();
+
+    printf(_("Setup system views ... \n"));
+    (void)fflush(stdout);
     setup_sysviews();
+
 #ifdef ENABLE_PRIVATEGAUSS
     setup_privsysviews();
 #endif

--- a/src/gausskernel/process/postmaster/postmaster.cpp
+++ b/src/gausskernel/process/postmaster/postmaster.cpp
@@ -3017,7 +3017,7 @@ static int ServerLoop(void)
          *
          * Before GRAND VERSION NUM 81000, we do not support scheduled job.
          */
-        if (g_instance.pid_cxt.PgJobSchdPID == 0 && pmState == PM_RUN &&
+        if (!g_instance.k2_cxt.isK2ModelEnabled && g_instance.pid_cxt.PgJobSchdPID == 0 && pmState == PM_RUN &&
             (g_instance.attr.attr_sql.job_queue_processes || t_thrd.postmaster_cxt.start_job_scheduler) &&
             u_sess->attr.attr_common.upgrade_mode != 1) {
             g_instance.pid_cxt.PgJobSchdPID = initialize_util_thread(JOB_SCHEDULER);
@@ -5455,7 +5455,7 @@ static void reaper(SIGNAL_ARGS)
                 g_instance.pid_cxt.AutoVacPID = initialize_util_thread(AUTOVACUUM_LAUNCHER);
 
             /* Before GRAND VERSION NUM 81000, we do not support scheduled job. */
-            if (g_instance.pid_cxt.PgJobSchdPID == 0 &&
+            if (!g_instance.k2_cxt.isK2ModelEnabled && g_instance.pid_cxt.PgJobSchdPID == 0 &&
                 g_instance.attr.attr_sql.job_queue_processes && u_sess->attr.attr_common.upgrade_mode != 1)
                 g_instance.pid_cxt.PgJobSchdPID = initialize_util_thread(JOB_SCHEDULER);
 
@@ -8175,8 +8175,10 @@ static void sigusr1_handler(SIGNAL_ARGS)
         StartCleanStatement();
     }
 
-    if (CheckPostmasterSignal(PMSIGNAL_START_JOB_SCHEDULER)) {
+    if (!g_instance.k2_cxt.isK2ModelEnabled && CheckPostmasterSignal(PMSIGNAL_START_JOB_SCHEDULER)) {
         t_thrd.postmaster_cxt.start_job_scheduler = true;
+    } else {
+        t_thrd.postmaster_cxt.start_job_scheduler = false;
     }
 
     if (CheckPostmasterSignal(PMSIGNAL_START_JOB_WORKER) &&


### PR DESCRIPTION
resolve the following issue

2022-11-14 18:54:44.582 [unknown] [unknown] localhost 140337435633408 0[0:0#0]  0 [BACKEND] FATAL:  could not open relation mapping file "global/pg_filenode.map": No such file or directory
2022-11-14 18:54:44.582 [unknown] [unknown] localhost 140336680654592 0[0:0#0]  0 [BACKEND] FATAL:  could not open relation mapping file "global/pg_filenode.map": No such file or directory
2022-11-14 18:54:44.582 [unknown] [unknown] localhost 140336848434944 0[0:0#0]  0 [BACKEND] FATAL:  could not open relation mapping file "global/pg_filenode.map": No such file or directory

2022-11-14 18:54:44.586 [unknown] [unknown] localhost 140339374824768 0[0:0#0]  0 [BACKEND] LOG:  job scheduler process (ThreadId 140337452414720) was terminated by signal 1: Hangup


and disabled job scheduler.