### PR TITLE
refactor K2PgInitPostgresBackend into two calls

### DIFF
--- a/src/common/backend/utils/init/postinit.cpp
+++ b/src/common/backend/utils/init/postinit.cpp
@@ -1976,6 +1976,9 @@ void PostgresInitializer::InitStreamSession()
 
 void PostgresInitializer::InitSysCache()
 {
+    // make sure that we initialize PgGate session before load sys cache
+    K2PgInitSession(m_indbname == NULL ? DEFAULT_DATABASE : m_indbname);
+
     /*
      * Initialize the relation cache and the system catalog caches.  Note that
      * no catalog access happens here; we only set up the hashtable structure.

--- a/src/common/backend/utils/init/postinit.cpp
+++ b/src/common/backend/utils/init/postinit.cpp
@@ -1919,6 +1919,8 @@ void PostgresInitializer::InitThread()
 
 void PostgresInitializer::InitSession()
 {
+    K2PgInitSession(m_dbname);
+
     /* Init rel cache for new session. */
     InitSysCache();
 
@@ -2062,6 +2064,8 @@ void PostgresInitializer::CheckAtLeastOneRoles()
 
 void PostgresInitializer::SetSuperUserAndDatabase()
 {
+    K2PgInitSession(m_indbname);
+
     /*
      * In the wlm worker thread, we set the user is super user
      * and the database is default database, we will send the query

--- a/src/gausskernel/bootstrap/bootstrap.cpp
+++ b/src/gausskernel/bootstrap/bootstrap.cpp
@@ -359,7 +359,8 @@ void BootStrapProcessMain(int argc, char* argv[])
             BootStrapXLOG();
             MemoryContextUnSeal(t_thrd.top_mem_cxt);
             /* Connect to K2PG cluster. */
-            K2PgInitPostgresBackend("postgres", nullptr, "");
+            K2PgInitPostgresBackend("postgres");
+            K2PgInitSession("template1");
             BootstrapModeMain();
             MemoryContextSeal(t_thrd.top_mem_cxt);
             proc_exit(1); /* should never return */

--- a/src/gausskernel/cbb/instruments/ash/ash.cpp
+++ b/src/gausskernel/cbb/instruments/ash/ash.cpp
@@ -61,6 +61,7 @@
 #include "utils/snapmgr.h"
 #include "access/tableam.h"
 #include "utils/fmgroids.h"
+#include "access/k2/k2pg_aux.h"
 
 #define NUM_UNIQUE_SQL_PARTITIONS 64
 #define UINT32_ACCESS_ONCE(var) ((uint32)(*((volatile uint32*)&(var))))
@@ -1092,6 +1093,8 @@ NON_EXEC_STATIC void ActiveSessionCollectMain()
 #ifndef EXEC_BACKEND
     InitProcess();
 #endif
+
+    K2PgInitPostgresBackend("ActiveSessionCollectMain");
     t_thrd.proc_cxt.PostInit->SetDatabaseAndUser((char*)pstrdup(DEFAULT_DATABASE), InvalidOid, username);
     t_thrd.proc_cxt.PostInit->InitAspWorker();
     SetProcessingMode(NormalProcessing);

--- a/src/gausskernel/cbb/instruments/percentile/percentile.cpp
+++ b/src/gausskernel/cbb/instruments/percentile/percentile.cpp
@@ -45,6 +45,7 @@
 #include "pgxc/poolutils.h"
 #include "instruments/percentile.h"
 #include "utils/postinit.h"
+#include "access/k2/k2pg_aux.h"
 
 extern void destroy_handles();
 const int SLEEP_INTERVAL = 10;
@@ -186,6 +187,8 @@ NON_EXEC_STATIC void PercentileMain()
 #ifndef EXEC_BACKEND
     InitProcess();
 #endif
+
+    K2PgInitPostgresBackend("PercentileMain");
 
     t_thrd.proc_cxt.PostInit->SetDatabaseAndUser((char*)pstrdup(DEFAULT_DATABASE), InvalidOid, username);
     t_thrd.proc_cxt.PostInit->InitPercentileWorker();

--- a/src/gausskernel/cbb/instruments/statement/instr_statement.cpp
+++ b/src/gausskernel/cbb/instruments/statement/instr_statement.cpp
@@ -65,7 +65,7 @@
 #include "utils/relcache.h"
 #include "commands/copy.h"
 
-#include "access/k2/pg_gate_api.h"
+#include "access/k2/k2pg_aux.h"
 
 #define MAX_SLOW_QUERY_RETENSION_DAYS 604800
 #define MAX_FULL_SQL_RETENSION_SEC 86400
@@ -649,6 +649,8 @@ NON_EXEC_STATIC void StatementFlushMain()
 #ifndef EXEC_BACKEND
     InitProcess();
 #endif
+
+    K2PgInitPostgresBackend("StatementFlushMain");
     t_thrd.proc_cxt.PostInit->SetDatabaseAndUser((char*)pstrdup(DEFAULT_DATABASE), InvalidOid, username);
     t_thrd.proc_cxt.PostInit->InitStatementWorker();
     SetProcessingMode(NormalProcessing);
@@ -1422,7 +1424,7 @@ void instr_stmt_report_basic_info()
         ResourceOwnerDelete(tmpOwner);
         if (to_update_db_name || to_update_user_name || to_update_client_addr) {
             // start a new PG Gate session if any changes in db, user name, or client address
-            PgGate_InitSession(u_sess->statement_cxt.db_name);
+            K2PgInitSession(u_sess->statement_cxt.db_name);
         }
     }
 }

--- a/src/gausskernel/cbb/instruments/wdr/snapshot.cpp
+++ b/src/gausskernel/cbb/instruments/wdr/snapshot.cpp
@@ -63,6 +63,7 @@
 #include "instruments/dblink_query.h"
 #include "libpq/pqsignal.h"
 #include "pgxc/groupmgr.h"
+#include "access/k2/k2pg_aux.h"
 
 const int PGSTAT_RESTART_INTERVAL = 60;
 #define MAX_INT ((unsigned)(-1) >> 1)
@@ -1438,6 +1439,8 @@ NON_EXEC_STATIC void SnapshotMain()
 #ifndef EXEC_BACKEND
     InitProcess();
 #endif
+
+    K2PgInitPostgresBackend("SnapshotMain");
 
     t_thrd.proc_cxt.PostInit->SetDatabaseAndUser((char*)pstrdup(DEFAULT_DATABASE), InvalidOid, username);
     t_thrd.proc_cxt.PostInit->InitSnapshotWorker();

--- a/src/gausskernel/cbb/workload/ioschdl.cpp
+++ b/src/gausskernel/cbb/workload/ioschdl.cpp
@@ -49,6 +49,8 @@
 #include "pgxc/poolutils.h"
 #endif
 
+#include "access/k2/k2pg_aux.h"
+
 static void WLMmonitor_MainLoop(void);
 static void WLMmonitor_worker(int type);
 
@@ -1191,6 +1193,7 @@ NON_EXEC_STATIC void WLMmonitorMain(void)
     /* Early initialization */
     BaseInit();
 
+    K2PgInitPostgresBackend("WLMmonitorMain");
     WLMInitPostgres();
 
     SetProcessingMode(NormalProcessing);
@@ -1514,6 +1517,7 @@ NON_EXEC_STATIC void WLMarbiterMain(void)
 
     /* Early initialization */
     BaseInit();
+    K2PgInitPostgresBackend("WLMarbiterMain");
     WLMInitPostgres();
 
     SetProcessingMode(NormalProcessing);

--- a/src/gausskernel/process/job/job_scheduler.cpp
+++ b/src/gausskernel/process/job/job_scheduler.cpp
@@ -69,6 +69,7 @@
 #include "job/job_shmem.h"
 #include "job/job_scheduler.h"
 #include "gssignal/gs_signal.h"
+#include "access/k2/k2pg_aux.h"
 
 /* the minimum allowed time between two awakenings of the launcher */
 #define MIN_JOB_SCHEDULE_SLEEPTIME 100  /* milliseconds */
@@ -196,6 +197,7 @@ NON_EXEC_STATIC void JobScheduleMain()
     InitProcess();
 #endif
 
+    K2PgInitPostgresBackend("JobScheduleMain");
     /* Initialize openGauss with DEFAULT_DATABASE, since it cannot be dropped */
     t_thrd.proc_cxt.PostInit->SetDatabaseAndUser(dbname, InvalidOid, username);
     t_thrd.proc_cxt.PostInit->InitJobScheduler();

--- a/src/gausskernel/process/postmaster/autovacuum.cpp
+++ b/src/gausskernel/process/postmaster/autovacuum.cpp
@@ -123,6 +123,7 @@
 #include "common/config/cm_config.h"
 #include "catalog/pg_namespace.h"
 #include "storage/lmgr.h"
+#include "access/k2/k2pg_aux.h"
 
 /* struct to keep tuples stat that fetchs from DataNode */
 typedef struct avw_info {
@@ -268,6 +269,7 @@ NON_EXEC_STATIC void AutoVacLauncherMain()
     InitProcess();
 #endif
 
+    K2PgInitPostgresBackend("AutoVacLauncherMain");
     t_thrd.proc_cxt.PostInit->SetDatabaseAndUser(NULL, InvalidOid, NULL);
     t_thrd.proc_cxt.PostInit->InitAutoVacLauncher();
 

--- a/src/gausskernel/process/postmaster/postmaster.cpp
+++ b/src/gausskernel/process/postmaster/postmaster.cpp
@@ -11262,6 +11262,8 @@ int GaussDbThreadMain(knl_thread_arg* arg)
      */
     process_shared_preload_libraries();
 
+    K2PgInitPostgresBackend("GaussDbThreadMain");
+
     switch (thread_role) {
         case STREAM_WORKER:
         case THREADPOOL_STREAM: {

--- a/src/gausskernel/process/tcop/postgres.cpp
+++ b/src/gausskernel/process/tcop/postgres.cpp
@@ -7316,6 +7316,10 @@ int PostgresMain(int argc, char* argv[], const char* dbname, const char* usernam
     /* Initialize the memory tracking information */
     MemoryTrackingInit();
 
+    /* Connect to K2PG cluster. */
+    K2PgInitPostgresBackend("PostgresMain");
+    K2PgInitSession(dbname);
+
     /*
      * General initialization.
      *
@@ -7324,9 +7328,6 @@ int PostgresMain(int argc, char* argv[], const char* dbname, const char* usernam
      * involves database access should be there, not here.
      */
     t_thrd.proc_cxt.PostInit->SetDatabaseAndUser(dbname, InvalidOid, username);
-
-    /* Connect to K2PG cluster. */
-	K2PgInitPostgresBackend("postgres", dbname, username);
 
     /*
      * PostgresMain thread can be user for wal sender, which will call

--- a/src/gausskernel/storage/access/k2/k2pg_aux.cpp
+++ b/src/gausskernel/storage/access/k2/k2pg_aux.cpp
@@ -237,31 +237,36 @@ FetchUniqueConstraintName(Oid relation_id, char* dest, size_t max_size)
 	RelationClose(rel);
 }
 
-void
-K2PgInitPostgresBackend(
-	const char *program_name,
-	const char *db_name,
-	const char *user_name)
+void K2PgInitPostgresBackend(const char *program_name)
 {
-	HandleK2PgStatus(K2PgInit(program_name, (K2PgPAllocFn)palloc, (K2PgCStringToTextWithLenFn)cstring_to_text_with_len));
-
+	if (K2PgIsEnabledInPostgresEnvVar() && !g_instance.k2_cxt.isK2ModelEnabled) {
+		g_instance.k2_cxt.isK2ModelEnabled = true;
+	}
 	/*
-	 * Enable "K2PG mode" for PostgreSQL so that we will initiate a connection
-	 * to the K2 platform cluster right away from every backend process. We only
-
-	 * do this if this env variable is set, so we can still run the regular
-	 * PostgreSQL "make check".
+	 * Enable "K2PG mode" for PostgreSQL globally, the session will be initialized by each individual thread
 	 */
-	if (K2PgIsEnabledInPostgresEnvVar())
-	{
-		PgGate_InitPgGate();
+	if (g_instance.k2_cxt.isK2ModelEnabled) {
+		elog(INFO, "Initializing K2PG backend for %s", program_name);
+	    HandleK2PgStatus(K2PgInit(program_name, (K2PgPAllocFn)palloc, (K2PgCStringToTextWithLenFn)cstring_to_text_with_len));
+        PgGate_InitPgGate();
+	}
+}
 
-		/*
-		 * For each process, we create one K2PG session for PostgreSQL to use
-		 * when accessing K2PG storage.
-		 *
-		 */
-        HandleK2PgStatus(PgGate_InitSession(db_name ? db_name : user_name));
+void K2PgInitSession(const char *db_name) {
+	/*
+	 * For each process, we create one K2PG session for PostgreSQL to use
+	 * when accessing K2PG storage.
+	 *
+	*/
+	if (IsK2PgEnabled()) {
+		if (db_name != NULL) {
+			elog(INFO, "Initialize K2PG session for database: %s", db_name);
+    		HandleK2PgStatus(PgGate_InitSession(db_name));
+		} else {
+			elog(INFO, "database name is null when Initialize K2PG session, skipping...");
+		}
+	} else {
+		ereport(ERROR, (errmsg("K2PG backend has not been initialized for database: %s", db_name)));
 	}
 }
 

--- a/src/gausskernel/storage/access/k2/k2pg_aux.cpp
+++ b/src/gausskernel/storage/access/k2/k2pg_aux.cpp
@@ -263,7 +263,8 @@ void K2PgInitSession(const char *db_name) {
 			elog(INFO, "Initialize K2PG session for database: %s", db_name);
     		HandleK2PgStatus(PgGate_InitSession(db_name));
 		} else {
-			elog(INFO, "database name is null when Initialize K2PG session, skipping...");
+			elog(INFO, "database name is null when Initialize K2PG session, use default database %s ", DEFAULT_DATABASE);
+			HandleK2PgStatus(PgGate_InitSession(DEFAULT_DATABASE));
 		}
 	} else {
 		ereport(ERROR, (errmsg("K2PG backend has not been initialized for database: %s", db_name)));

--- a/src/gausskernel/storage/access/k2/pg_memctx.cpp
+++ b/src/gausskernel/storage/access/k2/pg_memctx.cpp
@@ -56,7 +56,7 @@ PgMemctx *PgMemctx::Create() {
 }
 
 Status PgMemctx::Destroy(PgMemctx *handle) {
-  if (handle) {
+  if (handle != NULL) {
     if(postgres_process_memctxs.find(handle) == postgres_process_memctxs.end()) {
         Status status {
             .pg_code = ERRCODE_INTERNAL_ERROR,
@@ -68,13 +68,14 @@ Status PgMemctx::Destroy(PgMemctx *handle) {
     }
 
     postgres_process_memctxs.erase(handle);
+    handle = NULL;
   }
 
   return Status::OK;
 }
 
 Status PgMemctx::Reset(PgMemctx *handle) {
-  if (handle) {
+  if (handle != NULL) {
     if (postgres_process_memctxs.find(handle) == postgres_process_memctxs.end()) {
         Status status {
             .pg_code = ERRCODE_INTERNAL_ERROR,

--- a/src/gausskernel/storage/access/ustore/knl_undolauncher.cpp
+++ b/src/gausskernel/storage/access/ustore/knl_undolauncher.cpp
@@ -46,6 +46,7 @@
 #include "gssignal/gs_signal.h"
 #include "access/ustore/knl_undoworker.h"
 #include "access/ustore/knl_undorequest.h"
+#include "access/k2/k2pg_aux.h"
 
 static void UndolauncherSighupHandler(SIGNAL_ARGS);
 static void UndolauncherSigusr2Handler(SIGNAL_ARGS);
@@ -218,6 +219,7 @@ NON_EXEC_STATIC void UndoLauncherMain()
     InitProcess();
 #endif
 
+    K2PgInitPostgresBackend("UndoLauncherMain");
     t_thrd.proc_cxt.PostInit->SetDatabaseAndUser(NULL, InvalidOid, NULL);
     t_thrd.proc_cxt.PostInit->InitUndoLauncher();
 

--- a/src/include/access/k2/k2pg_aux.h
+++ b/src/include/access/k2/k2pg_aux.h
@@ -148,9 +148,9 @@ extern void HandleK2PgTableDescStatus(const K2PgStatus& status, K2PgTableDesc ta
  * K2PG initialization that needs to happen when a PostgreSQL backend process
  * is started. Reports errors using ereport.
  */
-extern void K2PgInitPostgresBackend(const char *program_name,
-								  const char *db_name,
-								  const char *user_name);
+extern void K2PgInitPostgresBackend(const char *program_name);
+
+extern void K2PgInitSession(const char *db_name);
 
 /*
  * This should be called on all exit paths from the PostgreSQL backend process.


### PR DESCRIPTION
refactor K2PgInitPostgresBackend into two calls, i.e., 

void K2PgInitPostgresBackend(const char *program_name)

and

void K2PgInitSession(const char *db_name)

The latter will be called for each thread/session. Removed user name from the api since we don't really use it.

Updated PgGate_InitPgGate() and PgGate_DestroyPgGate() to handle multiple concurrent calls.