### PR TITLE
update K2PgPrepareCacheRefreshIfNeeded to catch PG exception and other fixes

### DIFF
--- a/src/common/backend/utils/cache/catcache.cpp
+++ b/src/common/backend/utils/cache/catcache.cpp
@@ -2751,7 +2751,9 @@ static CatCTup* CatalogCacheCreateEntry(
         ct->tuple.t_self = dtp->t_self;
         ct->tuple.t_tableOid = dtp->t_tableOid;
         ct->tuple.t_bucketId = dtp->t_bucketId;
-        HEAPTUPLE_COPY_K2PGTID(dtp->t_k2pgctid, ct->tuple.t_k2pgctid);
+        if (IsK2PgEnabled()) {
+            HEAPTUPLE_COPY_K2PGTID(dtp->t_k2pgctid, ct->tuple.t_k2pgctid);
+        }
 #ifdef PGXC
         ct->tuple.t_xc_node_id = dtp->t_xc_node_id;
 #endif

--- a/src/gausskernel/storage/access/heap/heapam.cpp
+++ b/src/gausskernel/storage/access/heap/heapam.cpp
@@ -2790,7 +2790,6 @@ Oid heap_insert(Relation relation, HeapTuple tup, CommandId cid, int options, Bu
     }
 
     if (IsK2PgRelation(relation)) {
-        elog(LOG, "Using K2PG heap insert in %s", __func__);
         return K2PgExecuteInsert(relation, RelationGetDescr(relation), tup);
     }
     /*

--- a/src/gausskernel/storage/access/k2/k2pg_aux.cpp
+++ b/src/gausskernel/storage/access/k2/k2pg_aux.cpp
@@ -186,9 +186,7 @@ HandleK2PgStatus(const K2PgStatus& status)
         return;
     }
 
-	if (K2PgShouldReportErrorStatus()) {
-		elog(ERROR, "HandleK2PgStatus: %s", status.msg.c_str());
-	}
+    elog(ERROR, "HandleK2PgStatus: %s", status.msg.c_str());
 
     ereport(ERROR, (errcode(status.pg_code), errmsg("%s: %s", status.msg.c_str(), status.detail.c_str())));
 }

--- a/src/gausskernel/storage/access/k2/session.cpp
+++ b/src/gausskernel/storage/access/k2/session.cpp
@@ -48,6 +48,7 @@ static void K2XactCallback(XactEvent event, void* arg) {
     if (event == XACT_EVENT_START) {
         elog(DEBUG2, "XACT_EVENT_START");
         if (auto [status] = TXMgr.endTxn(sh::dto::EndAction::Abort).get(); (!status.is2xxOK() && status.code != 410)) {
+            K2LOG_E(log::k2pg, "XACT_EVENT_START, TXMgr abort previous txn failed due to: {}", status);
             reportXactError("TXMgr abort failed", status);
         }
 
@@ -58,16 +59,19 @@ static void K2XactCallback(XactEvent event, void* arg) {
             });
 
         if (auto [status] = TXMgr.beginTxn().get(); !status.is2xxOK()) {
+            K2LOG_E(log::k2pg, "XACT_EVENT_START, TXMgr begin failed due to: {}", status);
             reportXactError("TXMgr begin failed", status);
         }
     } else if (event == XACT_EVENT_COMMIT) {
         elog(DEBUG2, "XACT_EVENT_COMMIT");
         if (auto [status] = TXMgr.endTxn(sh::dto::EndAction::Commit).get(); !status.is2xxOK()) {
+            K2LOG_E(log::k2pg, "XACT_EVENT_COMMIT, TXMgr commit failed due to: {}", status);
             reportXactError("TXMgr commit failed", status);
         }
     } else if (event == XACT_EVENT_ABORT) {
         elog(DEBUG2, "XACT_EVENT_ABORT");
         if (auto [status] = TXMgr.endTxn(sh::dto::EndAction::Abort).get(); !status.is2xxOK()) {
+            K2LOG_E(log::k2pg, "XACT_EVENT_ABORT, TXMgr abort failed due to: {}", status);
             reportXactError("TXMgr abort failed", status);
         }
     }


### PR DESCRIPTION
make K2PgPrepareCacheRefreshIfNeeded() in the pg_catch clause and added exception logs.

