### PR TITLE
Catalog tuple delete

### DIFF
--- a/src/common/backend/catalog/aclchk.cpp
+++ b/src/common/backend/catalog/aclchk.cpp
@@ -134,41 +134,41 @@ const struct AclObjectType {
     AclMode all_ddl_privileges;
     const char* errormsg;
 } acl_object_type[] = {
-    {ACL_OBJECT_RELATION, (ACL_ALL_RIGHTS_RELATION | ACL_ALL_RIGHTS_SEQUENCE), 
+    {ACL_OBJECT_RELATION, (ACL_ALL_RIGHTS_RELATION | ACL_ALL_RIGHTS_SEQUENCE),
         ACL_ALL_DDL_RIGHTS_RELATION, gettext_noop("invalid privilege type %s for relation")},
-    {ACL_OBJECT_SEQUENCE, ACL_ALL_RIGHTS_SEQUENCE, ACL_ALL_DDL_RIGHTS_SEQUENCE, 
+    {ACL_OBJECT_SEQUENCE, ACL_ALL_RIGHTS_SEQUENCE, ACL_ALL_DDL_RIGHTS_SEQUENCE,
         gettext_noop("invalid privilege type %s for sequence")},
-    {ACL_OBJECT_DATABASE, ACL_ALL_RIGHTS_DATABASE, ACL_ALL_DDL_RIGHTS_DATABASE, 
+    {ACL_OBJECT_DATABASE, ACL_ALL_RIGHTS_DATABASE, ACL_ALL_DDL_RIGHTS_DATABASE,
         gettext_noop("invalid privilege type %s for database")},
-    {ACL_OBJECT_DOMAIN, ACL_ALL_RIGHTS_TYPE, ACL_ALL_DDL_RIGHTS_DOMAIN, 
+    {ACL_OBJECT_DOMAIN, ACL_ALL_RIGHTS_TYPE, ACL_ALL_DDL_RIGHTS_DOMAIN,
         gettext_noop("invalid privilege type %s for domain")},
-    {ACL_OBJECT_FUNCTION, ACL_ALL_RIGHTS_FUNCTION, ACL_ALL_DDL_RIGHTS_FUNCTION, 
+    {ACL_OBJECT_FUNCTION, ACL_ALL_RIGHTS_FUNCTION, ACL_ALL_DDL_RIGHTS_FUNCTION,
         gettext_noop("invalid privilege type %s for function")},
-    {ACL_OBJECT_LANGUAGE, ACL_ALL_RIGHTS_LANGUAGE, ACL_ALL_DDL_RIGHTS_LANGUAGE, 
+    {ACL_OBJECT_LANGUAGE, ACL_ALL_RIGHTS_LANGUAGE, ACL_ALL_DDL_RIGHTS_LANGUAGE,
         gettext_noop("invalid privilege type %s for language")},
-    {ACL_OBJECT_PACKAGE, ACL_ALL_RIGHTS_PACKAGE, ACL_ALL_DDL_RIGHTS_PACKAGE, 
+    {ACL_OBJECT_PACKAGE, ACL_ALL_RIGHTS_PACKAGE, ACL_ALL_DDL_RIGHTS_PACKAGE,
         gettext_noop("invalid privilege type %s for package")},
-    {ACL_OBJECT_LARGEOBJECT, ACL_ALL_RIGHTS_LARGEOBJECT, ACL_ALL_DDL_RIGHTS_LARGEOBJECT, 
+    {ACL_OBJECT_LARGEOBJECT, ACL_ALL_RIGHTS_LARGEOBJECT, ACL_ALL_DDL_RIGHTS_LARGEOBJECT,
         gettext_noop("invalid privilege type %s for large object")},
-    {ACL_OBJECT_NAMESPACE, ACL_ALL_RIGHTS_NAMESPACE, ACL_ALL_DDL_RIGHTS_NAMESPACE, 
+    {ACL_OBJECT_NAMESPACE, ACL_ALL_RIGHTS_NAMESPACE, ACL_ALL_DDL_RIGHTS_NAMESPACE,
         gettext_noop("invalid privilege type %s for schema")},
-    {ACL_OBJECT_NODEGROUP, ACL_ALL_RIGHTS_NODEGROUP, ACL_ALL_DDL_RIGHTS_NODEGROUP, 
+    {ACL_OBJECT_NODEGROUP, ACL_ALL_RIGHTS_NODEGROUP, ACL_ALL_DDL_RIGHTS_NODEGROUP,
         gettext_noop("invalid privilege type %s for node group")},
-    {ACL_OBJECT_TABLESPACE, ACL_ALL_RIGHTS_TABLESPACE, ACL_ALL_DDL_RIGHTS_TABLESPACE, 
+    {ACL_OBJECT_TABLESPACE, ACL_ALL_RIGHTS_TABLESPACE, ACL_ALL_DDL_RIGHTS_TABLESPACE,
         gettext_noop("invalid privilege type %s for tablespace")},
-    {ACL_OBJECT_TYPE, ACL_ALL_RIGHTS_TYPE, ACL_ALL_DDL_RIGHTS_TYPE, 
+    {ACL_OBJECT_TYPE, ACL_ALL_RIGHTS_TYPE, ACL_ALL_DDL_RIGHTS_TYPE,
         gettext_noop("invalid privilege type %s for type")},
-    {ACL_OBJECT_FDW, ACL_ALL_RIGHTS_FDW, ACL_ALL_DDL_RIGHTS_FDW, 
+    {ACL_OBJECT_FDW, ACL_ALL_RIGHTS_FDW, ACL_ALL_DDL_RIGHTS_FDW,
         gettext_noop("invalid privilege type %s for foreign-data wrapper")},
-    {ACL_OBJECT_FOREIGN_SERVER, ACL_ALL_RIGHTS_FOREIGN_SERVER, ACL_ALL_DDL_RIGHTS_FOREIGN_SERVER, 
+    {ACL_OBJECT_FOREIGN_SERVER, ACL_ALL_RIGHTS_FOREIGN_SERVER, ACL_ALL_DDL_RIGHTS_FOREIGN_SERVER,
         gettext_noop("invalid privilege type %s for foreign server")},
-    {ACL_OBJECT_DATA_SOURCE, ACL_ALL_RIGHTS_DATA_SOURCE, ACL_ALL_DDL_RIGHTS_DATA_SOURCE, 
+    {ACL_OBJECT_DATA_SOURCE, ACL_ALL_RIGHTS_DATA_SOURCE, ACL_ALL_DDL_RIGHTS_DATA_SOURCE,
         gettext_noop("invalid privilege type %s for data source")},
-    {ACL_OBJECT_GLOBAL_SETTING, ACL_ALL_RIGHTS_KEY, ACL_ALL_DDL_RIGHTS_KEY, 
+    {ACL_OBJECT_GLOBAL_SETTING, ACL_ALL_RIGHTS_KEY, ACL_ALL_DDL_RIGHTS_KEY,
         gettext_noop("invalid privilege type %s for client master key")},
-    {ACL_OBJECT_COLUMN_SETTING, ACL_ALL_RIGHTS_KEY, ACL_ALL_DDL_RIGHTS_KEY, 
+    {ACL_OBJECT_COLUMN_SETTING, ACL_ALL_RIGHTS_KEY, ACL_ALL_DDL_RIGHTS_KEY,
         gettext_noop("invalid privilege type %s for column encryption key")},
-    {ACL_OBJECT_DIRECTORY, ACL_ALL_RIGHTS_DIRECTORY, ACL_ALL_DDL_RIGHTS_DIRECTORY, 
+    {ACL_OBJECT_DIRECTORY, ACL_ALL_RIGHTS_DIRECTORY, ACL_ALL_DDL_RIGHTS_DIRECTORY,
         gettext_noop("invalid privilege type %s for directory")},
 };
 
@@ -373,7 +373,7 @@ static void restrict_and_check_grant(AclMode* this_privileges, bool is_grant,
             break;
         }
     }
-    
+
     if (!kind_flag) {
         ereport(ERROR, (errmodule(MOD_SEC), errcode(ERRCODE_UNRECOGNIZED_NODE_TYPE),
             errmsg("unrecognized object kind: %d", objkind), errdetail("N/A"),
@@ -618,7 +618,7 @@ void ExecuteGrantStmt(GrantStmt* stmt)
                             errdetail("Column privileges are only valid for relations."),
                                 errcause("Column privileges are only valid for relations in GRANT/REVOKE."),
                                     erraction("Use the column privileges only for relations.")));
-                
+
                 if (privnode->priv_name == NULL) {
                     istmt.col_ddl_privs = lappend(istmt.col_ddl_privs, privnode);
                     istmt.col_privs = lappend(istmt.col_privs, privnode);
@@ -630,7 +630,7 @@ void ExecuteGrantStmt(GrantStmt* stmt)
                         istmt.col_privs = lappend(istmt.col_privs, privnode);
                     }
                 }
-                
+
                 continue;
             }
 
@@ -875,7 +875,7 @@ static List *objectNamesToOids(GrantObjectType objtype, List *objnames)
 
                 Oid dest_group(0);
                 char in_redis = get_pgxc_group_redistributionstatus(group_oid);
-                bool redis_valid_oid = (in_redis == PGXC_REDISTRIBUTION_SRC_GROUP) && 
+                bool redis_valid_oid = (in_redis == PGXC_REDISTRIBUTION_SRC_GROUP) &&
                                         (OidIsValid(dest_group = PgxcGroupGetRedistDestGroupOid()));
                 if (redis_valid_oid) {
                     objects = lappend_oid(objects, dest_group);
@@ -1741,7 +1741,7 @@ void RemoveDefaultACLById(Oid defaclOid)
             errmsg("could not find tuple for default ACL %u", defaclOid), errdetail("N/A"),
                 errcause("System error."), erraction("Contact engineer to support.")));
 
-    simple_heap_delete(rel, &tuple->t_self);
+    CatalogTupleDelete(rel, tuple);
     systable_endscan(scan);
     heap_close(rel, RowExclusiveLock);
 }
@@ -1806,7 +1806,7 @@ static void expand_all_col_privileges(
         if (curr_att == BucketIdAttributeNumber && !relhasbucket)
             continue;
         /* Views don't have any system columns at all */
-        if ((classForm->relkind == RELKIND_VIEW || classForm->relkind == RELKIND_CONTQUERY) 
+        if ((classForm->relkind == RELKIND_VIEW || classForm->relkind == RELKIND_CONTQUERY)
             && curr_att < 0)
             continue;
 
@@ -1923,7 +1923,7 @@ static void ExecGrant_Attribute(InternalGrant* istmt, Oid relOid, const char* re
      * whether a warning is issued, this seems close enough.
      */
     bool all_privs = ((col_privileges == ACL_ALL_RIGHTS_COLUMN) && (col_ddl_privileges == ACL_ALL_DDL_RIGHTS_COLUMN));
-    
+
     AclMode this_col_privileges[PRIVS_ATTR_NUM];
     restrict_and_check_grant(this_col_privileges, istmt->is_grant,
         avail_goptions,
@@ -3490,7 +3490,7 @@ static void set_nodegroup_all_privileges(InternalGrant* grantStmt) {
         grantStmt->privileges = ACL_ALL_RIGHTS_NODEGROUP;
         grantStmt->ddl_privileges = (t_thrd.proc->workingVersionNum >= PRIVS_VERSION_NUM) ?
             ACL_ALL_DDL_RIGHTS_NODEGROUP : ACL_NO_DDL_RIGHTS;
-    }    
+    }
 }
 
 /*
@@ -3547,7 +3547,7 @@ static void ExecGrant_NodeGroup(InternalGrant* grantStmt)
     ListCell* cell = NULL;
 
     /* set nodegroup all privileges */
-    set_nodegroup_all_privileges(grantStmt); 
+    set_nodegroup_all_privileges(grantStmt);
 
     relation = heap_open(PgxcGroupRelationId, RowExclusiveLock);
 
@@ -5009,7 +5009,7 @@ AclMode pg_class_aclmask(Oid table_oid, Oid roleid, AclMode mask, AclMaskHow how
      * protected in this way.  Assume the view rules can take care of
      * themselves.	ACL_USAGE is if we ever have system sequences.
      */
-    if (!is_ddl_privileges && (mask & (ACL_INSERT | ACL_UPDATE | ACL_DELETE | ACL_TRUNCATE | ACL_USAGE)) 
+    if (!is_ddl_privileges && (mask & (ACL_INSERT | ACL_UPDATE | ACL_DELETE | ACL_TRUNCATE | ACL_USAGE))
         && IsSystemClass(classForm) &&
         classForm->relkind != RELKIND_VIEW && classForm->relkind != RELKIND_CONTQUERY && !has_rolcatupdate(roleid) &&
         !g_instance.attr.attr_common.allowSystemTableMods) {
@@ -5718,7 +5718,7 @@ AclMode pg_tablespace_aclmask(Oid spc_oid, Oid roleid, AclMode mask, AclMaskHow 
     /* Database Security:  Support separation of privilege. */
     if (superuser_arg(roleid) || systemDBA_arg(roleid))
         return REMOVE_DDL_FLAG(mask);
-    
+
     if (isOperatoradmin(roleid) && u_sess->attr.attr_security.operation_mode) {
         return REMOVE_DDL_FLAG(mask);
     }
@@ -6431,7 +6431,7 @@ bool gs_sec_cmk_ownercheck(Oid key_oid, Oid roleid)
     }
     tuple = SearchSysCache1(GLOBALSETTINGOID, ObjectIdGetDatum(key_oid));
     if (!HeapTupleIsValid(tuple)) {
-        ereport(ERROR, (errmodule(MOD_SEC), errcode(ERRCODE_UNDEFINED_KEY), 
+        ereport(ERROR, (errmodule(MOD_SEC), errcode(ERRCODE_UNDEFINED_KEY),
             errmsg("client master key with OID %u does not exist", key_oid), errdetail("N/A"),
                 errcause("System error."), erraction("Contact engineer to support.")));
     }

--- a/src/common/backend/catalog/dependency.cpp
+++ b/src/common/backend/catalog/dependency.cpp
@@ -1097,7 +1097,7 @@ static void deleteOneObject(const ObjectAddress* object, Relation* depRel, int f
     scan = systable_beginscan(*depRel, DependDependerIndexId, true, NULL, nkeys, key);
 
     while (HeapTupleIsValid(tup = systable_getnext(scan))) {
-        simple_heap_delete(*depRel, &tup->t_self);
+        CatalogTupleDelete(*depRel, tup);
     }
 
     systable_endscan(scan);
@@ -1123,8 +1123,9 @@ static void deleteOneObject(const ObjectAddress* object, Relation* depRel, int f
         while (HeapTupleIsValid(tup = systable_getnext(scan))) {
             Form_pg_depend Pinnedobj = (Form_pg_depend)GETSTRUCT(tup);
 
-            if (Pinnedobj->deptype == DEPENDENCY_PIN)
-                simple_heap_delete(*depRel, &tup->t_self);
+            if (Pinnedobj->deptype == DEPENDENCY_PIN) {
+                CatalogTupleDelete(*depRel, tup);
+            }
         }
 
         systable_endscan(scan);

--- a/src/common/backend/catalog/gs_matview.cpp
+++ b/src/common/backend/catalog/gs_matview.cpp
@@ -168,7 +168,7 @@ void delete_matview_tuple(Oid matviewOid)
     }
 
     if (HeapTupleIsValid(tup)) {
-        simple_heap_delete(relation, &tup->t_self);
+        CatalogTupleDelete(relation, tup);
 
         /* clear up correlative matmap-table */
         if (HeapTupleIsValid(ScanPgRelation(matmapid, true, false))) {
@@ -292,8 +292,8 @@ void delete_matviewdep_tuple(Oid matviewOid)
     while((tup = (HeapTuple) tableam_scan_getnexttuple(scan, ForwardScanDirection)) != NULL) {
         matviewDepForm = (Form_gs_matview_dependency)GETSTRUCT(tup);
         try_delete_mlog_table(relation, matviewDepForm->mlogid);
-        simple_heap_delete(relation, &tup->t_self);
-    }
+        CatalogTupleDelete(relation, tup);
+   }
 
     tableam_scan_end(scan);
     heap_close(relation, NoLock);
@@ -323,7 +323,7 @@ void delete_matdep_table(Oid mlogid)
     scan = tableam_scan_begin(relation, SnapshotNow, 1, &scanKey);
 
     while((tup = (HeapTuple) tableam_scan_getnexttuple(scan, ForwardScanDirection)) != NULL) {
-        simple_heap_delete(relation, &tup->t_self);
+        CatalogTupleDelete(relation, tup);
         try_delete_mlog_table(relation, mlogid);
         matviewDepForm = (Form_gs_matview_dependency)GETSTRUCT(tup);
         delete_matview_tuple(matviewDepForm->matviewid);

--- a/src/common/backend/catalog/index.cpp
+++ b/src/common/backend/catalog/index.cpp
@@ -1831,7 +1831,7 @@ void index_drop(Oid indexId, bool concurrent)
 
     hasexprs = !heap_attisnull(tuple, Anum_pg_index_indexprs, NULL);
 
-    simple_heap_delete(indexRelation, &tuple->t_self);
+    CatalogTupleDelete(indexRelation, tuple);
 
     ReleaseSysCache(tuple);
     heap_close(indexRelation, RowExclusiveLock);

--- a/src/common/backend/catalog/indexing.cpp
+++ b/src/common/backend/catalog/indexing.cpp
@@ -243,6 +243,15 @@ CatalogIndexDelete(CatalogIndexState indstate, HeapTuple heapTuple)
 	ExecDropSingleTupleTableSlot(slot);
 }
 
+void CatalogTupleDelete(Relation heapRel, HeapTuple tup)
+{
+    if (IsK2PgRelation(heapRel)) {
+        K2PgDeleteSysCatalogTuple(heapRel, tup);
+    } else {
+        simple_heap_delete(heapRel, &tup->t_self);
+    }
+}
+
 /*
  * CatalogUpdateIndexes - do all the indexing work for a new catalog tuple
  *

--- a/src/common/backend/catalog/pg_collation.cpp
+++ b/src/common/backend/catalog/pg_collation.cpp
@@ -155,11 +155,12 @@ void RemoveCollationById(Oid collationOid)
 
     tuple = systable_getnext(scandesc);
 
-    if (HeapTupleIsValid(tuple))
-        simple_heap_delete(rel, &tuple->t_self);
-    else
+    if (HeapTupleIsValid(tuple)) {
+        CatalogTupleDelete(rel, tuple);
+    } else {
         ereport(ERROR,
             (errcode(ERRCODE_CACHE_LOOKUP_FAILED), errmsg("could not find tuple for collation %u", collationOid)));
+    }
 
     systable_endscan(scandesc);
 

--- a/src/common/backend/catalog/pg_constraint.cpp
+++ b/src/common/backend/catalog/pg_constraint.cpp
@@ -560,7 +560,7 @@ void RemoveConstraintById(Oid conId)
             ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("constraint %u is not of a known type", conId)));
 
     /* Fry the constraint itself */
-    simple_heap_delete(conDesc, &tup->t_self);
+    CatalogTupleDelete(conDesc, tup);
 
     /* Clean up */
     ReleaseSysCache(tup);

--- a/src/common/backend/catalog/pg_conversion.cpp
+++ b/src/common/backend/catalog/pg_conversion.cpp
@@ -152,11 +152,12 @@ void RemoveConversionById(Oid conversionOid)
     scan = heap_beginscan(rel, SnapshotNow, 1, &scanKeyData);
 
     /* search for the target tuple */
-    if (HeapTupleIsValid(tuple = heap_getnext(scan, ForwardScanDirection)))
-        simple_heap_delete(rel, &tuple->t_self);
-    else
+    if (HeapTupleIsValid(tuple = heap_getnext(scan, ForwardScanDirection))) {
+        CatalogTupleDelete(rel, tuple);
+    } else {
         ereport(ERROR,
             (errcode(ERRCODE_CACHE_LOOKUP_FAILED), errmsg("could not find tuple for conversion %u", conversionOid)));
+    }
     heap_endscan(scan);
     heap_close(rel, RowExclusiveLock);
 }

--- a/src/common/backend/catalog/pg_db_role_setting.cpp
+++ b/src/common/backend/catalog/pg_db_role_setting.cpp
@@ -111,8 +111,9 @@ void AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt* setstmt)
 
                 /* Update indexes */
                 CatalogUpdateIndexes(rel, newtuple);
-            } else
-                simple_heap_delete(rel, &tuple->t_self);
+            } else {
+                CatalogTupleDelete(rel, tuple);
+            }
         }
     } else if (HeapTupleIsValid(tuple)) {
         Datum repl_val[Natts_pg_db_role_setting];
@@ -147,8 +148,9 @@ void AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt* setstmt)
 
             /* Update indexes */
             CatalogUpdateIndexes(rel, newtuple);
-        } else
-            simple_heap_delete(rel, &tuple->t_self);
+        } else {
+            CatalogTupleDelete(rel, tuple);
+        }
     } else if (valuestr != NULL) {
         /* non-null valuestr means it's not RESET, so insert a new tuple */
         HeapTuple newtuple = NULL;
@@ -211,7 +213,7 @@ void DropSetting(Oid databaseid, Oid roleid)
 
     scan = heap_beginscan(relsetting, SnapshotNow, numkeys, keys);
     while (HeapTupleIsValid(tup = heap_getnext(scan, ForwardScanDirection))) {
-        simple_heap_delete(relsetting, &tup->t_self);
+        CatalogTupleDelete(relsetting, tup);
     }
     heap_endscan(scan);
 

--- a/src/common/backend/catalog/pg_depend.cpp
+++ b/src/common/backend/catalog/pg_depend.cpp
@@ -259,7 +259,7 @@ long deleteDependencyRecordsFor(Oid classId, Oid objectId, bool skipExtensionDep
         if (skipExtensionDeps && ((Form_pg_depend)GETSTRUCT(tup))->deptype == DEPENDENCY_EXTENSION)
             continue;
 
-        simple_heap_delete(depRel, &tup->t_self);
+        CatalogTupleDelete(depRel, tup);
         count++;
     }
 
@@ -300,7 +300,7 @@ long deleteDependencyRecordsForClass(Oid classId, Oid objectId, Oid refclassId, 
         Form_pg_depend depform = (Form_pg_depend)GETSTRUCT(tup);
 
         if (depform->refclassid == refclassId && depform->deptype == deptype) {
-            simple_heap_delete(depRel, &tup->t_self);
+            CatalogTupleDelete(depRel, tup);
             count++;
         }
     }
@@ -370,9 +370,9 @@ long changeDependencyFor(Oid classId, Oid objectId, Oid refClassId, Oid oldRefOb
         Form_pg_depend depform = (Form_pg_depend)GETSTRUCT(tup);
 
         if (depform->refclassid == refClassId && depform->refobjid == oldRefObjectId) {
-            if (newIsPinned)
-                simple_heap_delete(depRel, &tup->t_self);
-            else {
+            if (newIsPinned) {
+                CatalogTupleDelete(depRel, tup);
+            } else {
                 /* make a modifiable copy */
                 tup = heap_copytuple(tup);
                 depform = (Form_pg_depend)GETSTRUCT(tup);

--- a/src/common/backend/catalog/pg_enum.cpp
+++ b/src/common/backend/catalog/pg_enum.cpp
@@ -148,7 +148,7 @@ void EnumValuesDelete(Oid enumTypeOid)
     scan = systable_beginscan(pg_enum, EnumTypIdLabelIndexId, true, NULL, 1, key);
 
     while (HeapTupleIsValid(tup = systable_getnext(scan))) {
-        simple_heap_delete(pg_enum, &tup->t_self);
+        CatalogTupleDelete(pg_enum, tup);
     }
 
     systable_endscan(scan);

--- a/src/common/backend/catalog/pg_largeobject.cpp
+++ b/src/common/backend/catalog/pg_largeobject.cpp
@@ -101,7 +101,7 @@ void LargeObjectDrop(Oid loid)
     if (!HeapTupleIsValid(tuple))
         ereport(ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("large object %u does not exist", loid)));
 
-    simple_heap_delete(pg_lo_meta, &tuple->t_self);
+    CatalogTupleDelete(pg_lo_meta, tuple);
 
     systable_endscan(scan);
 
@@ -112,7 +112,7 @@ void LargeObjectDrop(Oid loid)
 
     scan = systable_beginscan(pg_largeobject, LargeObjectLOidPNIndexId, true, NULL, 1, skey);
     while (HeapTupleIsValid(tuple = systable_getnext(scan))) {
-        simple_heap_delete(pg_largeobject, &tuple->t_self);
+        CatalogTupleDelete(pg_largeobject, tuple);
     }
 
     systable_endscan(scan);

--- a/src/common/backend/catalog/pg_proc.cpp
+++ b/src/common/backend/catalog/pg_proc.cpp
@@ -582,7 +582,7 @@ static bool checkPackageFunctionConflicts(
                 continue;
             Datum packageid_datum = SysCacheGetAttr(PROCOID, proctup, Anum_pg_proc_packageid, &isNull);
             Oid packageid = ObjectIdGetDatum(packageid_datum);
-            if (packageid != propackageid) 
+            if (packageid != propackageid)
                 continue;
             Datum propackage = SysCacheGetAttr(PROCOID, proctup, Anum_pg_proc_package, &isNull);
             bool ispackage = false;
@@ -728,7 +728,7 @@ static void checkFunctionConflicts(HeapTuple oldtup, const char* procedureName, 
                 }
                 Relation gs_rel = heap_open(ClientLogicProcId, RowExclusiveLock);
                 deleteDependencyRecordsFor(ClientLogicProcId, HeapTupleGetOid(gs_oldtup), true);
-                simple_heap_delete(gs_rel, &gs_oldtup->t_self);
+                CatalogTupleDelete(gs_rel, gs_oldtup);
                 heap_close(gs_rel, RowExclusiveLock);
                 ReleaseSysCache(gs_oldtup);
             }
@@ -869,7 +869,7 @@ static void cfunction_check_user(const char* probin)
 inline void IsLeavingDefaultPath(const char* path)
 {
     if (strstr(path, "../") != NULL) {
-        ereport(ERROR, 
+        ereport(ERROR,
             (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("Path \"%s\" is not admitted. Don't use \"../\" "
                 "when enable_default_cfunc_libpath is on.", path)));
     }
@@ -1313,7 +1313,7 @@ Oid ProcedureCreate(const char* procedureName, Oid procNamespace, Oid propackage
         if (OidIsValid(propackageid)) {
             pkgname = GetPackageName(propackageid);
         }
-        if (pkgname == NULL) { 
+        if (pkgname == NULL) {
             name = list_make2(makeString(get_namespace_name(procNamespace)), makeString(pstrdup(procedureName)));
         } else {
             name = list_make3(makeString(get_namespace_name(procNamespace)), makeString(pstrdup(pkgname->data)), makeString(pstrdup(procedureName)));
@@ -1355,17 +1355,17 @@ Oid ProcedureCreate(const char* procedureName, Oid procNamespace, Oid propackage
                                    "Do not allow different package have same function name with same parameter,"
                                    "please drop package by oid %d first", oldPkgOid)));
                 }
-            } 
+            }
             if (OidIsValid(propackageid) && !OidIsValid(oldPkgOid)) {
                     ereport(ERROR,
                         (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
                             errmsg("Do not allow have same function name with same parameter in this version,"
-                                   "please drop function first.")));               
+                                   "please drop function first.")));
             } else if (!OidIsValid(propackageid) && OidIsValid(oldPkgOid)) {
                     ereport(ERROR,
                         (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
                             errmsg("Do not allow have same function name with same parameter in this version,"
-                                   "please drop package by oid %d first.", oldPkgOid)));            
+                                   "please drop package by oid %d first.", oldPkgOid)));
             }
         }
         checkFunctionConflicts(oldtup,
@@ -2242,27 +2242,27 @@ Node *plpgsql_create_proc_operator_ref(ParseState *pstate, Node *left, Node *rig
 /*
  * judage the two arglis is same or not
  */
-bool isSameArgList(List* argList1, List* argList2) 
+bool isSameArgList(List* argList1, List* argList2)
 {
     ListCell* cell =  NULL;
     int length1 = list_length(argList1);
     int length2 = list_length(argList2);
-    
+
     if (length1 != length2) {
         return false;
-    }    
+    }
     FunctionParameter* arr1[length1];
     FunctionParameter* arr2[length2];
-    int length = 0; 
+    int length = 0;
     foreach(cell, argList1) {
         arr1[length] = (FunctionParameter*)lfirst(cell);
-        length = length + 1; 
-    }    
-    length = 0; 
+        length = length + 1;
+    }
+    length = 0;
     foreach(cell, argList2) {
         arr2[length] = (FunctionParameter*)lfirst(cell);
-        length = length + 1; 
-    }    
+        length = length + 1;
+    }
     for (int i = 0; i < length1; i++) {
         FunctionParameter* fp1 = arr1[i];
         FunctionParameter* fp2 = arr2[i];
@@ -2304,8 +2304,8 @@ bool isSameArgList(List* argList1, List* argList2)
         }
         if (toid1 != toid2 || fp1->mode != fp2->mode) {
             return false;
-        } 
-    }    
+        }
+    }
     return true;
 }
 

--- a/src/common/backend/catalog/pg_range.cpp
+++ b/src/common/backend/catalog/pg_range.cpp
@@ -119,7 +119,7 @@ void RangeDelete(Oid rangeTypeOid)
     scan = systable_beginscan(pg_range, RangeTypidIndexId, true, NULL, 1, key);
 
     while (HeapTupleIsValid(tup = systable_getnext(scan))) {
-        simple_heap_delete(pg_range, &tup->t_self);
+        CatalogTupleDelete(pg_range, tup);
     }
 
     systable_endscan(scan);

--- a/src/common/backend/catalog/pg_shdepend.cpp
+++ b/src/common/backend/catalog/pg_shdepend.cpp
@@ -237,7 +237,7 @@ static void shdepChangeDep(Relation sdepRel, Oid classid, Oid objid, int32 objsu
     if (objfile_isnull && isSharedObjectPinned(refclassid, refobjid, sdepRel)) {
         /* No new entry needed, so just delete existing entry if any */
         if (oldtup != NULL)
-            simple_heap_delete(sdepRel, &oldtup->t_self);
+            CatalogTupleDelete(sdepRel, oldtup);
     } else if (oldtup != NULL) {
         /* Need to update existing entry */
         Form_pg_shdepend shForm = (Form_pg_shdepend)GETSTRUCT(oldtup);
@@ -795,7 +795,7 @@ void dropDatabaseDependencies(Oid databaseId)
         /* Forward drop stmt to MOT FDW. */
         MotFdwDropDatabaseDependency(tup);
 #endif
-        simple_heap_delete(sdepRel, &tup->t_self);
+        CatalogTupleDelete(sdepRel, tup);
     }
 
     systable_endscan(scan);
@@ -931,7 +931,7 @@ static void shdepDropDependency(Relation sdepRel, Oid classId, Oid objectId, int
             continue;
 
         /* OK, delete it */
-        simple_heap_delete(sdepRel, &tup->t_self);
+        CatalogTupleDelete(sdepRel, tup);
     }
 
     systable_endscan(scan);
@@ -1685,7 +1685,7 @@ void changeDependencyOnObjfile(Oid objectId, Oid refobjId, const char* newObjfil
     } else {
         if (ispinned && newObjfile == NULL) {
             /* No entry needed, just delete the existing entry */
-            simple_heap_delete(sdepRel, &oldtup->t_self);
+            CatalogTupleDelete(sdepRel, oldtup);
         } else {
             /* Update the existing entry */
             Datum repl_val[Natts_pg_shdepend];

--- a/src/gausskernel/optimizer/commands/dbcommands.cpp
+++ b/src/gausskernel/optimizer/commands/dbcommands.cpp
@@ -1089,7 +1089,7 @@ void dropdb(const char* dbname, bool missing_ok)
     if (!HeapTupleIsValid(tup))
         ereport(ERROR, (errcode(ERRCODE_CACHE_LOOKUP_FAILED), errmsg("cache lookup failed for database %u", db_id)));
 
-    simple_heap_delete(pgdbrel, &tup->t_self);
+    CatalogTupleDelete(pgdbrel, tup);
 
     ReleaseSysCache(tup);
 

--- a/src/gausskernel/optimizer/commands/extension.cpp
+++ b/src/gausskernel/optimizer/commands/extension.cpp
@@ -1576,7 +1576,7 @@ void RemoveExtensionById(Oid extId)
 
     /* We assume that there can be at most one matching tuple */
     if (HeapTupleIsValid(tuple))
-        simple_heap_delete(rel, &tuple->t_self);
+        CatalogTupleDelete(rel, tuple);
 
     systable_endscan(scandesc);
 

--- a/src/gausskernel/optimizer/commands/opclasscmds.cpp
+++ b/src/gausskernel/optimizer/commands/opclasscmds.cpp
@@ -442,7 +442,7 @@ void DefineOpClass(CreateOpClassStmt* stmt)
                 }
 
                 if (item->order_family)
-                    sortfamilyOid = get_opfamily_oid(BTREE_AM_OID, item->order_family, false); 
+                    sortfamilyOid = get_opfamily_oid(BTREE_AM_OID, item->order_family, false);
                 else
                     sortfamilyOid = InvalidOid;
 
@@ -778,7 +778,7 @@ static void AlterOpFamilyAdd(
                 }
 
                 if (item->order_family)
-                    sortfamilyOid = get_opfamily_oid(BTREE_AM_OID, item->order_family, false); 
+                    sortfamilyOid = get_opfamily_oid(BTREE_AM_OID, item->order_family, false);
                 else
                     sortfamilyOid = InvalidOid;
 
@@ -1420,7 +1420,7 @@ void RemoveOpFamilyById(Oid opfamilyOid)
         ereport(
             ERROR, (errcode(ERRCODE_CACHE_LOOKUP_FAILED), errmsg("cache lookup failed for opfamily %u", opfamilyOid)));
 
-    simple_heap_delete(rel, &tup->t_self);
+    CatalogTupleDelete(rel, tup);
 
     ReleaseSysCache(tup);
 
@@ -1439,7 +1439,7 @@ void RemoveOpClassById(Oid opclassOid)
         ereport(
             ERROR, (errcode(ERRCODE_CACHE_LOOKUP_FAILED), errmsg("cache lookup failed for opclass %u", opclassOid)));
 
-    simple_heap_delete(rel, &tup->t_self);
+    CatalogTupleDelete(rel, tup);
 
     ReleaseSysCache(tup);
 
@@ -1464,7 +1464,7 @@ void RemoveAmOpEntryById(Oid entryOid)
     if (!HeapTupleIsValid(tup))
         ereport(ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("could not find tuple for amop entry %u", entryOid)));
 
-    simple_heap_delete(rel, &tup->t_self);
+    CatalogTupleDelete(rel, tup);
 
     systable_endscan(scan);
     heap_close(rel, RowExclusiveLock);
@@ -1489,7 +1489,7 @@ void RemoveAmProcEntryById(Oid entryOid)
         ereport(
             ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("could not find tuple for amproc entry %u", entryOid)));
 
-    simple_heap_delete(rel, &tup->t_self);
+    CatalogTupleDelete(rel, tup);
 
     systable_endscan(scan);
     heap_close(rel, RowExclusiveLock);

--- a/src/gausskernel/optimizer/commands/operatorcmds.cpp
+++ b/src/gausskernel/optimizer/commands/operatorcmds.cpp
@@ -348,7 +348,7 @@ void RemoveOperatorById(Oid operOid)
     if (!HeapTupleIsValid(tup)) /* should not happen */
         ereport(ERROR, (errcode(ERRCODE_CACHE_LOOKUP_FAILED), errmsg("cache lookup failed for operator %u", operOid)));
 
-    simple_heap_delete(relation, &tup->t_self);
+    CatalogTupleDelete(relation, tup);
 
     ReleaseSysCache(tup);
 

--- a/src/gausskernel/optimizer/commands/schemacmds.cpp
+++ b/src/gausskernel/optimizer/commands/schemacmds.cpp
@@ -403,7 +403,7 @@ void RemoveSchemaById(Oid schemaOid)
         ereport(
             ERROR, (errcode(ERRCODE_CACHE_LOOKUP_FAILED), errmsg("cache lookup failed for namespace %u", schemaOid)));
 
-    simple_heap_delete(relation, &tup->t_self);
+    CatalogTupleDelete(relation, tup);
 
     ReleaseSysCache(tup);
 

--- a/src/gausskernel/optimizer/commands/trigger.cpp
+++ b/src/gausskernel/optimizer/commands/trigger.cpp
@@ -1081,7 +1081,7 @@ void RemoveTriggerById(Oid trigOid)
     /*
      * Delete the pg_trigger tuple.
      */
-    simple_heap_delete(tgrel, &tup->t_self);
+    CatalogTupleDelete(tgrel, tup);
 
     systable_endscan(tgscan);
     heap_close(tgrel, RowExclusiveLock);

--- a/src/gausskernel/optimizer/rewrite/rewriteRemove.cpp
+++ b/src/gausskernel/optimizer/rewrite/rewriteRemove.cpp
@@ -72,7 +72,7 @@ void RemoveRewriteRuleById(Oid ruleOid)
     /*
      * Now delete the pg_rewrite tuple for the rule
      */
-    simple_heap_delete(RewriteRelation, &tuple->t_self);
+    CatalogTupleDelete(RewriteRelation, tuple);
 
     systable_endscan(rcscan);
 

--- a/src/gausskernel/runtime/executor/functions.cpp
+++ b/src/gausskernel/runtime/executor/functions.cpp
@@ -1802,7 +1802,7 @@ bool check_sql_fn_retval(Oid func_id, Oid ret_type, List* query_tree_list, bool*
             } else if (!IsBinaryCoercible(tle_type, att_type) &&
                 /*
                  * if the data type mismatch is because of it is client_logic, it's OK at this point
-                 * we just need to validate that it does not conflict with the original data type 
+                 * we just need to validate that it does not conflict with the original data type
                  */
                 !(IsClientLogicType(att_type) && IsBinaryCoercible(tle_type, attr->atttypmod))) {
                 ereport(ERROR,
@@ -2060,12 +2060,12 @@ bool sql_fn_cl_rewrite_params(const Oid func_id, SQLFunctionParseInfoPtr p_info,
                 Assert(oldtup != tuple);
                 HeapTuple old_gs_tup = SearchSysCache1(GSCLPROCID, ObjectIdGetDatum(HeapTupleGetOid(oldtup)));
                 deleteDependencyRecordsFor(ProcedureRelationId, HeapTupleGetOid(oldtup), true);
-                simple_heap_delete(rel, &oldtup->t_self);
+                CatalogTupleDelete(rel, oldtup);
                 ReleaseSysCache(oldtup);
                 if (HeapTupleIsValid(old_gs_tup)) {
                     gs_rel = heap_open(ClientLogicProcId, RowExclusiveLock);
                     deleteDependencyRecordsFor(ClientLogicProcId, HeapTupleGetOid(old_gs_tup), true);
-                    simple_heap_delete(gs_rel, &old_gs_tup->t_self);
+                    CatalogTupleDelete(gs_rel, old_gs_tup);
                     heap_close(gs_rel, RowExclusiveLock);
                     ReleaseSysCache(old_gs_tup);
                 }

--- a/src/gausskernel/runtime/executor/nodeModifyTable.cpp
+++ b/src/gausskernel/runtime/executor/nodeModifyTable.cpp
@@ -1237,9 +1237,9 @@ TupleTableSlot* ExecDelete(ItemPointer tupleid, Oid deletePartitionOid, int2 buc
 		{
 			/* Delete index entries of the old tuple
             *
-            * TODO: double check the logic here
             */
-			ExecDeleteIndexTuples(planSlot, tupleid, estate, part_relation, partition, NULL, false);
+            ItemPointer k2pg_ctid = (ItemPointer)DatumGetPointer(K2PgGetPgTupleIdFromSlot(planSlot));
+			ExecDeleteIndexTuples(planSlot, k2pg_ctid, estate, part_relation, partition, NULL, false);
 		}
     } else {
         /*
@@ -1731,13 +1731,12 @@ TupleTableSlot* ExecUpdate(ItemPointer tupleid,
 		 */
 		if (K2PgRelInfoHasSecondaryIndices(result_rel_info))
 		{
+            ItemPointer item = (ItemPointer)DatumGetPointer(((HeapTuple)tuple)->t_k2pgctid);
 			/* Delete index entries of the old tuple */
-            ExecDeleteIndexTuples(slot, tupleid, estate, fake_part_rel, partition, NULL, false);
+            ExecDeleteIndexTuples(slot, item, estate, fake_part_rel, partition, NULL, false);
 
 			/* Insert new index entries for tuple */
-            List* recheckIndexes = NIL;
-            ItemPointer item = (ItemPointer)DatumGetPointer(((HeapTuple)tuple)->t_k2pgctid);
-            recheckIndexes = ExecInsertIndexTuples(slot, item, estate, fake_part_rel, partition, bucketid, NULL, NULL);
+            List* recheckIndexes = ExecInsertIndexTuples(slot, item, estate, fake_part_rel, partition, bucketid, NULL, NULL);
 		}
 	} else {
         bool update_indexes = false;

--- a/src/gausskernel/storage/access/heap/heapam.cpp
+++ b/src/gausskernel/storage/access/heap/heapam.cpp
@@ -4180,11 +4180,8 @@ TM_Result heap_delete(Relation relation, ItemPointer tid, CommandId cid,
     /* Don't allow any write/lock operator in stream. */
     Assert(!StreamThreadAmI());
 
-    if (IsK2PgRelation(relation))
-    {
-        elog(WARNING, "Ignoring unsupported tuple delete for rel %s",
-		    RelationGetRelationName(relation));
-        return TM_Ok;
+    if (IsK2PgRelation(relation)) {
+        ereport(ERROR, (errcode(ERRCODE_INVALID_OPERATION), errmsg("Invalid call on heap_delete for k2 relation %d", relation->rd_id)));
     }
 
     /*
@@ -4553,6 +4550,10 @@ void simple_heap_delete(Relation relation, ItemPointer tid, int options, bool al
 {
     TM_Result result;
     TM_FailureData tmfd;
+
+    if (IsK2PgRelation(relation)) {
+        ereport(ERROR, (errcode(ERRCODE_INVALID_OPERATION), errmsg("Invalid call on simple_heap_delete for k2 relation %d", relation->rd_id)));
+    }
 
     result = tableam_tuple_delete(relation,
         tid,

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -36,6 +36,7 @@ extern void CatalogIndexInsert(CatalogIndexState indstate,
 				   HeapTuple heapTuple);
 extern void CatalogUpdateIndexes(Relation heapRel, HeapTuple heapTuple);
 extern Oid	CatalogTupleInsert(Relation heapRel, HeapTuple tup);
+extern void CatalogTupleDelete(Relation heapRel, HeapTuple tup);
 
 
 /*


### PR DESCRIPTION
introduce CatalogTupleDelete() to replace some of the simple_tuple_delete() call to delegate to K2PgDeleteSysCatalogTuple() for k2 relations