### PR TITLE
Index update fixes

### DIFF
--- a/src/common/backend/catalog/indexing.cpp
+++ b/src/common/backend/catalog/indexing.cpp
@@ -231,13 +231,12 @@ CatalogIndexDelete(CatalogIndexState indstate, HeapTuple heapTuple)
 
 		/*
 		 * The index AM does the rest.
-         *
-         * TODO: check how to use t_k2pgctid in ItemPointerData
 		 */
+        ItemPointer t_self = IsK2PgRelation(relationDescs[i]) ? (ItemPointer)(heapTuple->t_k2pgctid) : &(heapTuple->t_self);
 		index_delete(relationDescs[i],	/* index relation */
 					 values,	/* array of index Datums */
 					 isnull,	/* is-null flags */
-                     &(heapTuple->t_self));
+                     t_self);
 	}
 
 	ExecDropSingleTupleTableSlot(slot);

--- a/src/common/backend/catalog/indexing.cpp
+++ b/src/common/backend/catalog/indexing.cpp
@@ -260,20 +260,17 @@ void CatalogUpdateIndexes(Relation heapRel, HeapTuple heapTuple)
 	{
 		HeapTuple	oldtup = NULL;
 		bool		has_indices = K2PgRelHasSecondaryIndices(heapRel);
-
 		if (has_indices)
 		{
 			if (heapTuple->t_k2pgctid)
 			{
-				oldtup = CamFetchTuple(heapRel, heapTuple->t_k2pgctid);
-				CatalogIndexDelete(indstate, oldtup);
+				CatalogIndexDelete(indstate, heapTuple);
 			}
 			else
 				elog(WARNING, "k2pgctid missing in %s's tuple",
 								RelationGetRelationName(heapRel));
 		}
 
-		K2PgUpdateSysCatalogTuple(heapRel, oldtup, heapTuple);
 		/* Update the local cache automatically */
 		K2PgSetSysCacheTuple(heapRel, heapTuple);
 

--- a/src/gausskernel/runtime/executor/execUtils.cpp
+++ b/src/gausskernel/runtime/executor/execUtils.cpp
@@ -46,6 +46,8 @@
 #include "access/sysattr.h"
 #include "access/transam.h"
 #include "access/tableam.h"
+#include "access/k2/k2pg_aux.h"
+#include "access/k2/k2_table_ops.h"
 #include "catalog/index.h"
 #include "catalog/heap.h"
 #include "catalog/namespace.h"
@@ -1384,7 +1386,8 @@ void ExecDeleteIndexTuples(TupleTableSlot* slot, ItemPointer tupleid, EState* es
          */
         FormIndexDatum(indexInfo, slot, estate, values, isnull);
 
-        index_delete(actualindex, values, isnull, tupleid);
+        ItemPointer t_self = IsK2PgRelation(actualindex) ? (ItemPointer)K2PgGetPgTupleIdFromSlot(slot) : tupleid;
+        index_delete(actualindex, values, isnull, t_self);
     }
 
     list_free_ext(partitionIndexOidList);


### PR DESCRIPTION
- Fix calls to index_delete so that the proper k2pgctid is used
- Remove the base table fetch call in CatalogUpdateIndexes which was bugged and not needed