### PR TITLE
K2pgctid update delete

### DIFF
--- a/src/gausskernel/optimizer/commands/copy.cpp
+++ b/src/gausskernel/optimizer/commands/copy.cpp
@@ -3938,7 +3938,8 @@ static uint64 CopyFrom(CopyState cstate)
      * inserting to, and act differently if the tuples that have already been
      * processed and prepared for insertion are not there.
      */
-    if ((resultRelInfo->ri_TrigDesc != NULL &&
+    if (IsK2PgRelation(cstate->rel) ||
+        (resultRelInfo->ri_TrigDesc != NULL &&
         (resultRelInfo->ri_TrigDesc->trig_insert_before_row || resultRelInfo->ri_TrigDesc->trig_insert_instead_row)) ||
         cstate->volatile_defexprs) {
         useHeapMultiInsert = false;

--- a/src/gausskernel/optimizer/commands/trigger.cpp
+++ b/src/gausskernel/optimizer/commands/trigger.cpp
@@ -73,6 +73,8 @@
 #include "optimizer/pgxcship.h"
 #endif
 
+#include "access/k2/k2pg_aux.h"
+
 /*
  * Note that similar macros also exist in executor/execMain.c.  There does not
  * appear to be any good header to put them into, given the structures that
@@ -2911,7 +2913,7 @@ ltrmark:;
             tuple.t_self = *tid;
             tuple.t_tableOid = RelationGetRelid(fakeRelation);
             tuple.t_bucketId = RelationGetBktid(fakeRelation);
- 		    tuple.t_k2pgctid = PointerGetDatum(NULL);
+ 		    tuple.t_k2pgctid = (Datum) 0;
             HeapTupleCopyBaseFromPage(&tuple, page);
 #ifdef PGXC
             tuple.t_xc_node_id = u_sess->pgxc_cxt.PGXCNodeIdentifier;
@@ -2972,7 +2974,7 @@ static bool TriggerEnabled(EState* estate, ResultRelInfo* relinfo, Trigger* trig
 
         modified = false;
         for (i = 0; i < trigger->tgnattr; i++) {
-            if (bms_is_member(trigger->tgattr[i] - FirstLowInvalidHeapAttributeNumber, modifiedCols)) {
+            if (bms_is_member(trigger->tgattr[i] - K2PgGetFirstLowInvalidAttributeNumber(relinfo->ri_RelationDesc), modifiedCols)) {
                 modified = true;
                 break;
             }

--- a/src/gausskernel/runtime/executor/execMain.cpp
+++ b/src/gausskernel/runtime/executor/execMain.cpp
@@ -94,6 +94,8 @@
 #include "gs_ledger/ledger_utils.h"
 #include "gs_policy/gs_policy_masking.h"
 
+//#include "access/k2/k2pg_aux.h"
+
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
 THR_LOCAL ExecutorStart_hook_type ExecutorStart_hook = NULL;
 THR_LOCAL ExecutorRun_hook_type ExecutorRun_hook = NULL;
@@ -2445,20 +2447,18 @@ void ExecConstraints(ResultRelInfo *resultRelInfo, TupleTableSlot *slot, EState 
 
 
         for (attrChk = 1; attrChk <= natts; attrChk++) {
+        	// Form_pg_attribute att = TupleDescAttr(tupdesc, attrChk - 1);
 
-        // TODO: do we need some logic similar to the below?
-        //		// 	Form_pg_attribute att = TupleDescAttr(tupdesc, attrChk - 1);
-
-		// 	if (mtstate && mtstate->k2pg_mt_is_single_row_update_or_delete &&
-		// 	    !bms_is_member(att->attnum - K2PgGetFirstLowInvalidAttributeNumber(rel), modifiedCols))
-		// 	{
-		// 		/*
-		// 		 * For single-row-updates, we only know the values of the
-		// 		 * modified columns. But in this case it is safe to skip the
-		// 		 * unmodified columns anyway.
-		// 		 */
-		// 		continue;
-		// 	}
+			// if (mtstate && mtstate->k2pg_mt_is_single_row_update_or_delete &&
+			//     !bms_is_member(att->attnum - K2PgGetFirstLowInvalidAttributeNumber(rel), modifiedCols))
+			// {
+			// 	/*
+			// 	 * For single-row-updates, we only know the values of the
+			// 	 * modified columns. But in this case it is safe to skip the
+			// 	 * unmodified columns anyway.
+			// 	 */
+			// 	continue;
+			// }
 
             if (tupdesc->attrs[attrChk - 1]->attnotnull && tableam_tslot_attisnull(slot, attrChk)) {
                 char *val_desc = NULL;

--- a/src/gausskernel/runtime/executor/execMain.cpp
+++ b/src/gausskernel/runtime/executor/execMain.cpp
@@ -94,8 +94,6 @@
 #include "gs_ledger/ledger_utils.h"
 #include "gs_policy/gs_policy_masking.h"
 
-//#include "access/k2/k2pg_aux.h"
-
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
 THR_LOCAL ExecutorStart_hook_type ExecutorStart_hook = NULL;
 THR_LOCAL ExecutorRun_hook_type ExecutorRun_hook = NULL;
@@ -2447,19 +2445,6 @@ void ExecConstraints(ResultRelInfo *resultRelInfo, TupleTableSlot *slot, EState 
 
 
         for (attrChk = 1; attrChk <= natts; attrChk++) {
-        	// Form_pg_attribute att = TupleDescAttr(tupdesc, attrChk - 1);
-
-			// if (mtstate && mtstate->k2pg_mt_is_single_row_update_or_delete &&
-			//     !bms_is_member(att->attnum - K2PgGetFirstLowInvalidAttributeNumber(rel), modifiedCols))
-			// {
-			// 	/*
-			// 	 * For single-row-updates, we only know the values of the
-			// 	 * modified columns. But in this case it is safe to skip the
-			// 	 * unmodified columns anyway.
-			// 	 */
-			// 	continue;
-			// }
-
             if (tupdesc->attrs[attrChk - 1]->attnotnull && tableam_tslot_attisnull(slot, attrChk)) {
                 char *val_desc = NULL;
                 bool rel_masked = u_sess->attr.attr_security.Enable_Security_Policy &&

--- a/src/gausskernel/runtime/executor/nodeModifyTable.cpp
+++ b/src/gausskernel/runtime/executor/nodeModifyTable.cpp
@@ -1711,8 +1711,6 @@ TupleTableSlot* ExecUpdate(ItemPointer tupleid,
         /* FDW might have changed tuple */
         tuple = tableam_tslot_get_tuple_from_slot(result_relation_desc, slot);
     } else if (IsK2PgRelation(result_relation_desc)) {
-        // TODO: double check the logic here
-
 		/*
 		 * Check the constraints of the tuple.
 		 */
@@ -2894,9 +2892,6 @@ TupleTableSlot* ExecModifyTable(ModifyTableState* node)
 					if (isNull)
 						elog(ERROR, "k2pgctid is NULL");
 
-					// old_tuple->t_k2pgctid = datum;
-
-					// // oldtuple = &oldtupdata;
                     tuple_id = (ItemPointer)DatumGetPointer(datum);
                     tuple_ctid = *tuple_id; /* be sure we don't free ctid!! */
                     tuple_id = &tuple_ctid;
@@ -3478,7 +3473,6 @@ ModifyTableState* ExecInitModifyTable(ModifyTable* node, EState* estate, int efl
             case CMD_UPDATE:
             case CMD_DELETE:
             case CMD_MERGE:
- //               junk_filter_needed = true;
 				/*
 				 * If it's a K2PG single row UPDATE/DELETE we do not perform an
 				 * initial scan to populate the k2pgctid, so there is no junk

--- a/src/gausskernel/storage/access/k2/k2_table_ops.cpp
+++ b/src/gausskernel/storage/access/k2/k2_table_ops.cpp
@@ -186,10 +186,6 @@ Datum K2PgGetPgTupleIdFromSlot(TupleTableSlot *slot)
 		}
 	}
 
-	// if (slot->tts_k2pgctid != 0) {
-	// 	return slot->tts_k2pgctid;
-	// }
-
 	return 0;
 }
 

--- a/src/gausskernel/storage/access/k2/k2_table_ops.cpp
+++ b/src/gausskernel/storage/access/k2/k2_table_ops.cpp
@@ -445,7 +445,8 @@ void K2PgExecuteInsertIndex(Relation index,
 	Oid            dboid    = K2PgGetDatabaseOid(index);
 	Oid            relid    = RelationGetRelid(index);
     std::vector<K2PgAttributeDef> columns;
-    bool upsert = false;
+	// TODO: fix me
+    bool upsert = true;
 
 	PrepareIndexWriteStmt(index, values, isnull,
 						  RelationGetNumberOfAttributes(index),

--- a/src/gausskernel/storage/access/k2/k2_table_ops.cpp
+++ b/src/gausskernel/storage/access/k2/k2_table_ops.cpp
@@ -186,6 +186,10 @@ Datum K2PgGetPgTupleIdFromSlot(TupleTableSlot *slot)
 		}
 	}
 
+	// if (slot->tts_k2pgctid != 0) {
+	// 	return slot->tts_k2pgctid;
+	// }
+
 	return 0;
 }
 
@@ -224,7 +228,7 @@ Datum K2PgGetPgTupleIdFromTuple(Relation rel,
 			// if this code adapted from chogori-sql is correct
 			k2attr.value.datum = 0;
 			k2attr.value.is_null = false;
-			k2attr.value.type_id = OIDOID;
+			k2attr.value.type_id = BYTEAOID;
 		}
 
 		attrs.push_back(k2attr);
@@ -473,20 +477,8 @@ bool K2PgExecuteDelete(Relation rel, TupleTableSlot *slot, EState *estate, Modif
 	/*
 	 * Look for k2pgctid. Raise error if k2pgctid is not found.
 	 *
-	 * If single row delete, generate k2pgctid from tuple values, otherwise
-	 * retrieve it from the slot.
 	 */
-	if (isSingleRow)
-	{
-		HeapTuple tuple = ExecMaterializeSlot(slot);
-		k2pgctid = K2PgGetPgTupleIdFromTuple(rel,
-										  tuple,
-										  slot->tts_tupleDescriptor);
-	}
-	else
-	{
-		k2pgctid = K2PgGetPgTupleIdFromSlot(slot);
-	}
+	k2pgctid = K2PgGetPgTupleIdFromSlot(slot);
 
 	if (k2pgctid == 0)
 	{
@@ -617,17 +609,10 @@ bool K2PgExecuteUpdate(Relation rel,
 	/*
 	 * Look for k2pgctid. Raise error if k2pgctid is not found.
 	 *
-	 * If single row update, generate k2pgctid from tuple values, otherwise
-	 * retrieve it from the slot.
 	 */
-	if (isSingleRow)
-	{
-		k2pgctid = K2PgGetPgTupleIdFromTuple(rel,
-										  tuple,
-										  slot->tts_tupleDescriptor);
-	}
-	else
-	{
+	if (tuple != NULL && tuple->t_k2pgctid != 0) {
+		k2pgctid = tuple->t_k2pgctid;
+	} else {
 		k2pgctid = K2PgGetPgTupleIdFromSlot(slot);
 	}
 

--- a/src/gausskernel/storage/access/k2/k2catam.cpp
+++ b/src/gausskernel/storage/access/k2/k2catam.cpp
@@ -1068,10 +1068,11 @@ camBeginScan(Relation relation, Relation index, bool xs_want_itup, int nkeys, Sc
 	 * Note: This works because we do not allow modifying schemas (alter/drop)
 	 * for system catalog tables.
 	 */
-	if (!IsSystemRelation(relation))
-	{
-		HandleK2PgStatus(PgGate_SetCatalogCacheVersion((K2PgStatement)camScan->handle, k2pg_catalog_cache_version));
-	}
+	// TODO Add this back when we consolidate PGStatement and K2PGScanHandle
+	// if (!IsSystemRelation(relation))
+	// {
+	// 	HandleK2PgStatus(PgGate_SetCatalogCacheVersion((K2PgStatement)camScan->handle, k2pg_catalog_cache_version));
+	// }
 
 	bms_free(scan_plan.hash_key);
 	bms_free(scan_plan.primary_key);


### PR DESCRIPTION
Picked from bugbash branch.
-----------------------------

commit 26d58d0643cbc1bda2c0349351fc69a812b3249b (HEAD -> k2pgctid-update-delete, origin/k2pgctid-update-delete)
Author: johnfangAFW <jfang@futurewei.com>
Date:   Thu Dec 8 20:29:30 2022 -0800

    clean up code

commit ca35b2c6212ef30c34641bebc6995cbfe7d47eff
Author: Ahsan Khan <ahsankhanmail@gmail.com>
Date:   Tue Dec 6 12:51:15 2022 -0800

    Skip set catalog cache version to fix segv (#111)
    
    Co-authored-by: Ahsan Khan <akhan@futurewei.com>

commit fff405f8e52d4e84ece7c759dff723bfcbb3b6b6
Author: johnfangAFW <jfang@futurewei.com>
Date:   Thu Dec 8 13:04:02 2022 -0800

    force to use upsert for k2 index insert

commit d0009f3c78baa4a0f93ee629bf6f1f282ce4c946
Author: johnfangAFW <jfang@futurewei.com>
Date:   Thu Dec 8 00:07:43 2022 -0800

    pass k2pg_ctid from scan slot to projected slot and assign it to heaptuple

commit 0c087f301ba7c6c02a831918fa995437bb181939
Author: johnfangAFW <jfang@futurewei.com>
Date:   Thu Dec 1 13:03:49 2022 -0800

    fix the k2pg_mt_is_single_row_update_or_delete logic