### PR TITLE
Mainline local initdb

### DIFF
--- a/simpleInstall/local_run.sh
+++ b/simpleInstall/local_run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+export GAUSSHOME=/opt/opengauss
+export GS_CLUSTER_NAME=dbCluster
+export GAUSSLOG=${GAUSSHOME}/logs
+export PGDATA=${GAUSSHOME}/data
+export PATH=${GAUSSHOME}/bin:${PATH}
+export LD_LIBRARY_PATH=${GAUSSHOME}/lib:${LD_LIBRARY_PATH}
+export K2PG_ENABLED_IN_POSTGRES=1
+export K2PG_TRANSACTIONS_ENABLED=1
+export K2PG_ALLOW_RUNNING_AS_ANY_USER=1
+export PG_NO_RESTART_ALL_CHILDREN_ON_CRASH=1
+export K2PG_LOCAL_NODE_INITDB=1
+
+cd ${GAUSSHOME}/simpleInstall/
+export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+export K2_CONFIG_FILE=${SCRIPT_DIR}/k2config_pgrun.json
+
+./install.sh "$@"

--- a/src/bin/initdb/initdb.cpp
+++ b/src/bin/initdb/initdb.cpp
@@ -442,6 +442,17 @@ void check_env_value(const char* input_env_value)
     }
 }
 
+static bool IsEnvSet(const char* name)
+{
+	const char* env_var_value = getenv(name);
+	return env_var_value != NULL && strcmp(env_var_value, "1") == 0;
+}
+
+static bool IsK2PgLocalNodeInitdb()
+{
+	return IsEnvSet("K2PG_LOCAL_NODE_INITDB");
+}
+
 /*
  * routines to check mem allocations and fail noisily.
  *
@@ -1426,33 +1437,33 @@ static void bootstrap_template1(void)
     }
 
     /* Substitute for various symbols used in the BKI file */
+    if (!IsK2PgLocalNodeInitdb()) {
+        nRet = sprintf_s(buf, BUF_LENGTH, "%d", NAMEDATALEN);
+        securec_check_ss_c(nRet, "\0", "\0");
+        bki_lines = replace_token(bki_lines, "NAMEDATALEN", buf);
 
-    nRet = sprintf_s(buf, BUF_LENGTH, "%d", NAMEDATALEN);
-    securec_check_ss_c(nRet, "\0", "\0");
-    bki_lines = replace_token(bki_lines, "NAMEDATALEN", buf);
+        nRet = sprintf_s(buf, BUF_LENGTH, "%d", (int)sizeof(Pointer));
+        securec_check_ss_c(nRet, "\0", "\0");
+        bki_lines = replace_token(bki_lines, "SIZEOF_POINTER", buf);
 
-    nRet = sprintf_s(buf, BUF_LENGTH, "%d", (int)sizeof(Pointer));
-    securec_check_ss_c(nRet, "\0", "\0");
-    bki_lines = replace_token(bki_lines, "SIZEOF_POINTER", buf);
+        bki_lines = replace_token(bki_lines, "ALIGNOF_POINTER", (sizeof(Pointer) == 4) ? "i" : "d");
 
-    bki_lines = replace_token(bki_lines, "ALIGNOF_POINTER", (sizeof(Pointer) == 4) ? "i" : "d");
+        bki_lines = replace_token(bki_lines, "FLOAT4PASSBYVAL", FLOAT4PASSBYVAL ? "true" : "false");
 
-    bki_lines = replace_token(bki_lines, "FLOAT4PASSBYVAL", FLOAT4PASSBYVAL ? "true" : "false");
+        bki_lines = replace_token(bki_lines, "FLOAT8PASSBYVAL", FLOAT8PASSBYVAL ? "true" : "false");
 
-    bki_lines = replace_token(bki_lines, "FLOAT8PASSBYVAL", FLOAT8PASSBYVAL ? "true" : "false");
+        bki_lines = replace_token(bki_lines, "POSTGRES", username);
 
-    bki_lines = replace_token(bki_lines, "POSTGRES", username);
+        bki_lines = replace_token(bki_lines, "ENCODING", encodingid);
 
-    bki_lines = replace_token(bki_lines, "ENCODING", encodingid);
+        buf_collate = escape_quotes(lc_collate);
+        bki_lines = replace_token(bki_lines, "LC_COLLATE", buf_collate);
+        FREE_AND_RESET_STR(buf_collate);
 
-    buf_collate = escape_quotes(lc_collate);
-    bki_lines = replace_token(bki_lines, "LC_COLLATE", buf_collate);
-    FREE_AND_RESET_STR(buf_collate);
-
-    buf_ctype = escape_quotes(lc_ctype);
-    bki_lines = replace_token(bki_lines, "LC_CTYPE", buf_ctype);
-    FREE_AND_RESET_STR(buf_ctype);
-
+        buf_ctype = escape_quotes(lc_ctype);
+        bki_lines = replace_token(bki_lines, "LC_CTYPE", buf_ctype);
+        FREE_AND_RESET_STR(buf_ctype);
+    }
     /*
      * "--dbcompatibility" is a required argument to set installed database compatibility.
      * We can choose --dbcompatibility=A\B\C.
@@ -1502,7 +1513,9 @@ static void bootstrap_template1(void)
     PG_CMD_OPEN;
 
     for (line = bki_lines; *line != NULL; line++) {
-        PG_CMD_PUTS(*line);
+        if (!IsK2PgLocalNodeInitdb()) {
+            PG_CMD_PUTS(*line);
+        }
         FREE_AND_RESET_STR(*line);
     }
 
@@ -4534,8 +4547,8 @@ int main(int argc, char* argv[])
     bootstrap_template1();
 
     /*
-     * Make the per-database PG_VERSION for template1 only after init'ing it
-     */
+    * Make the per-database PG_VERSION for template1 only after init'ing it
+    */
     printf(_("Write version file base/1 ... \n"));
     (void)fflush(stdout);
     write_version_file("base/1");
@@ -4544,102 +4557,111 @@ int main(int argc, char* argv[])
     (void)fflush(stdout);
     CreatePGDefaultTempDir();
 
-    /* Create the stuff we don't need to use bootstrap mode for */
+    if (!IsK2PgLocalNodeInitdb()) {
+        /* Create the stuff we don't need to use bootstrap mode for */
 
-    printf(_("Setup auth ... \n"));
-    (void)fflush(stdout);
-    setup_auth();
-    get_set_pwd();
-
-    printf(_("Setup depend ... \n"));
-    (void)fflush(stdout);
-    setup_depend();
-
-    printf(_("Load plpgsql ... \n"));
-    (void)fflush(stdout);
-    load_plpgsql();
-
-    printf(_("Setup system views ... \n"));
-    (void)fflush(stdout);
-    setup_sysviews();
-
-#ifdef ENABLE_PRIVATEGAUSS
-    setup_privsysviews();
-#endif
-    printf(_("Setup perf views ... \n"));
-    (void)fflush(stdout);
-    setup_perfviews();
-
-#ifdef PGXC
-    /* Initialize catalog information about the node self */
-    setup_nodeself();
-#endif
-
-    // TODO: should we exclude this step for k2_mode?
-    printf(_("Setup description ... \n"));
-    (void)fflush(stdout);
-    setup_description();
-
-    printf(_("Setup collation ... \n"));
-    (void)fflush(stdout);
-    setup_collation();
-
-    if (!k2_mode) {
-        printf(_("Setup conversion ... \n"));
+        printf(_("Setup auth ... \n"));
         (void)fflush(stdout);
-        setup_conversion();
+        setup_auth();
+        get_set_pwd();
 
-        printf(_("Setup directory ... \n"));
+        printf(_("Setup depend ... \n"));
         (void)fflush(stdout);
-        setup_dictionary();
+        setup_depend();
+
+        printf(_("Load plpgsql ... \n"));
+        (void)fflush(stdout);
+        load_plpgsql();
+
+        printf(_("Setup system views ... \n"));
+        (void)fflush(stdout);
+        setup_sysviews();
+
+    #ifdef ENABLE_PRIVATEGAUSS
+        setup_privsysviews();
+    #endif
+        printf(_("Setup perf views ... \n"));
+        (void)fflush(stdout);
+        setup_perfviews();
+
+    #ifdef PGXC
+        /* Initialize catalog information about the node self */
+        setup_nodeself();
+    #endif
+
+        // TODO: should we exclude this step for k2_mode?
+        printf(_("Setup description ... \n"));
+        (void)fflush(stdout);
+        setup_description();
+
+        printf(_("Setup collation ... \n"));
+        (void)fflush(stdout);
+        setup_collation();
+
+        if (!k2_mode) {
+            printf(_("Setup conversion ... \n"));
+            (void)fflush(stdout);
+            setup_conversion();
+
+            printf(_("Setup directory ... \n"));
+            (void)fflush(stdout);
+            setup_dictionary();
+        }
+
+        printf(_("Setup privileges ... \n"));
+        (void)fflush(stdout);
+        setup_privileges();
+
+        printf(_("Setup bucketmap len ... \n"));
+        (void)fflush(stdout);
+        setup_bucketmap_len();
+
+        printf(_("Setup schema ... \n"));
+        (void)fflush(stdout);
+        setup_schema();
+
+        printf(_("Load supported extension ... \n"));
+        (void)fflush(stdout);
+        load_supported_extension();
+
+        printf(_("Load update ... \n"));
+        (void)fflush(stdout);
+        setup_update();
+
+    #ifndef ENABLE_MULTIPLE_NODES
+        setup_snapshots();
+    #endif
+
+        if (!k2_mode) {
+            printf(_("Vacuum db ... \n"));
+            (void)fflush(stdout);
+            vacuum_db();
+        }
+
+        printf(_("Make template0 ... \n"));
+        (void)fflush(stdout);
+        make_template0();
+
+        printf(_("Make postgres ... \n"));
+        (void)fflush(stdout);
+        make_postgres();
+
+    #ifdef PGXC
+        if (!k2_mode) {
+            vacuumfreeze("template0");
+            vacuumfreeze("template1");
+            vacuumfreeze("postgres");
+        }
+    #endif
+        if (authwarning != NULL)
+            write_stderr("%s", authwarning);
+
+        printf(_("Finished initdb steps ...\n "));
+        (void)fflush(stdout);
+    } else {
+        printf(_("Initdb has already been done, skip steps ... \n"));
+        (void)fflush(stdout);
     }
-
-    printf(_("Setup privileges ... \n"));
-    (void)fflush(stdout);
-    setup_privileges();
-
-    printf(_("Setup bucketmap len ... \n"));
-    (void)fflush(stdout);
-    setup_bucketmap_len();
-
-    printf(_("Setup schema ... \n"));
-    (void)fflush(stdout);
-    setup_schema();
-
-    printf(_("Load supported extension ... \n"));
-    (void)fflush(stdout);
-    load_supported_extension();
-
-    printf(_("Load update ... \n"));
-    (void)fflush(stdout);
-    setup_update();
-
-#ifndef ENABLE_MULTIPLE_NODES
-    setup_snapshots();
-#endif
-
-    if (!k2_mode) {
-        printf(_("Vacuum db ... \n"));
-        (void)fflush(stdout);
-        vacuum_db();
-    }
-
-    printf(_("Make template0 ... \n"));
-    (void)fflush(stdout);
-    make_template0();
-
-    printf(_("Make postgres ... \n"));
-    (void)fflush(stdout);
-    make_postgres();
-
-#ifdef PGXC
-    vacuumfreeze("template0");
-    vacuumfreeze("template1");
-    vacuumfreeze("postgres");
-#endif
-
-    if (authwarning != NULL)
-        write_stderr("%s", authwarning);
 
     printf(_("Start executable ... \n"));
     (void)fflush(stdout);

--- a/src/common/backend/catalog/genbki.pl
+++ b/src/common/backend/catalog/genbki.pl
@@ -99,6 +99,8 @@ my $catalogs = Catalog::Catalogs(@input_files);
 # version marker for .bki file
 print BKI "# PostgreSQL $major_version\n";
 
+print BKI "k2pg_check_if_initdb_is_already_done\n";
+
 # vars to hold data needed for schemapg.h
 my %schemapg_entries;
 my @tables_needing_macros;

--- a/src/common/backend/utils/misc/postgresql_single.conf.sample
+++ b/src/common/backend/utils/misc/postgresql_single.conf.sample
@@ -83,7 +83,7 @@ max_connections = 200			# (change requires restart)
 # - Security and Authentication -
 
 #authentication_timeout = 1min		# 1s-600s
-session_timeout = 10min			# allowed duration of any unused session, 0s-86400s(1 day), 0 is disabled 
+session_timeout = 10min			# allowed duration of any unused session, 0s-86400s(1 day), 0 is disabled
 #ssl = off				# (change requires restart)
 #ssl_ciphers = 'ALL'			# allowed SSL ciphers
 					# (change requires restart)
@@ -245,7 +245,7 @@ incremental_checkpoint_timeout = 60s	# range 1s-1h
 
 # - heartbeat -
 #datanode_heartbeat_interval = 1s         # The heartbeat interval of the standby nodes.
-				 # The value is best configured less than half of 
+				 # The value is best configured less than half of
 				 # the wal_receiver_timeout and wal_sender_timeout.
 
 # - Sending Server(s) -
@@ -737,7 +737,7 @@ audit_enabled = on
 
 
 #------------------------------------------------------------------------------
-# ADIO 
+# ADIO
 #------------------------------------------------------------------------------
 #enable_adio_function = off
 #enable_fast_allocate = off
@@ -764,4 +764,5 @@ job_queue_processes = 10        # Number of concurrent jobs, optional: [0..1000]
 # DCF OPTIONS
 #------------------------------------------------------------------------------
 #enable_dcf = off
-
+# Disable 2pccleaner
+gs_clean_timeout = 0

--- a/src/gausskernel/bootstrap/bootstrap.cpp
+++ b/src/gausskernel/bootstrap/bootstrap.cpp
@@ -415,7 +415,7 @@ static void BootstrapModeMain(void)
      * In K2PG we only need to create the template1 database
      * (corresponding to creating the "base/1" subdir as its oid is hardcoded).
      */
-    if (IsK2PgEnabled())
+    if (IsK2PgEnabled() && !IsK2PgLocalNodeInitdbMode())
     {
         K2InitPGCluster();
 
@@ -443,7 +443,7 @@ static void BootstrapModeMain(void)
         RelationMapFinishBootstrap();
     }
 
-    if (IsK2PgEnabled())
+    if (IsK2PgEnabled() && !IsK2PgLocalNodeInitdbMode())
     {
         // set initDbDone to be true on K2 SKV
         K2FinishInitDB();

--- a/src/gausskernel/process/postmaster/twophasecleaner.cpp
+++ b/src/gausskernel/process/postmaster/twophasecleaner.cpp
@@ -446,7 +446,7 @@ static PGconn* LoginDatabase(char* host, int port, char* user, char* password,
     keywords[6] = "client_encoding";
     values[6] = encoding;
     keywords[7] = "connect_timeout";
-    values[7] = "5";
+    values[7] = "60";
     keywords[8] = "options";
     /* this mode: remove timeout */
     values[8] = "-c xc_maintenance_mode=on";

--- a/src/gausskernel/storage/access/k2/k2pg_aux.cpp
+++ b/src/gausskernel/storage/access/k2/k2pg_aux.cpp
@@ -27,22 +27,19 @@ int k2pg_pg_double_write = -1;
 int k2pg_disable_pg_locking = -1;
 
 
-bool
-IsK2PgEnabled()
+bool IsK2PgEnabled()
 {
 	/* We do not support Init/Bootstrap processing modes yet. */
 	return PgGate_IsK2PgEnabled();
 }
 
-void
-CheckIsK2PgSupportedRelation(Relation relation)
+void CheckIsK2PgSupportedRelation(Relation relation)
 {
 	const char relkind = relation->rd_rel->relkind;
 	CheckIsK2PgSupportedRelationByKind(relkind);
 }
 
-void
-CheckIsK2PgSupportedRelationByKind(char relkind)
+void CheckIsK2PgSupportedRelationByKind(char relkind)
 {
 	if (!(relkind == RELKIND_RELATION || relkind == RELKIND_INDEX ||
 		  relkind == RELKIND_VIEW || relkind == RELKIND_SEQUENCE ||
@@ -52,8 +49,7 @@ CheckIsK2PgSupportedRelationByKind(char relkind)
 								errmsg("This feature is not supported in K2PG.")));
 }
 
-bool
-IsK2PgRelation(Relation relation)
+bool IsK2PgRelation(Relation relation)
 {
 	if (!IsK2PgEnabled()) return false;
 
@@ -67,8 +63,7 @@ IsK2PgRelation(Relation relation)
 				 && relation->rd_rel->relpersistence != RELPERSISTENCE_TEMP;
 }
 
-bool
-IsK2PgRelationById(Oid relid)
+bool IsK2PgRelationById(Oid relid)
 {
 	Relation relation     = RelationIdGetRelation(relid);
 	bool     is_supported = IsK2PgRelation(relation);
@@ -76,8 +71,7 @@ IsK2PgRelationById(Oid relid)
 	return is_supported;
 }
 
-bool
-IsK2PgBackedRelation(Relation relation)
+bool IsK2PgBackedRelation(Relation relation)
 {
 	return IsK2PgRelation(relation) ||
 		(relation->rd_rel->relkind == RELKIND_VIEW &&
@@ -129,8 +123,7 @@ extern bool K2PgRelHasOldRowTriggers(Relation rel, CmdType operation)
 			trigdesc->trig_delete_before_row))));
 }
 
-bool
-K2PgRelHasSecondaryIndices(Relation relation)
+bool K2PgRelHasSecondaryIndices(Relation relation)
 {
 	if (!relation->rd_rel->relhasindex)
 		return false;
@@ -152,8 +145,7 @@ K2PgRelHasSecondaryIndices(Relation relation)
 	return has_indices;
 }
 
-bool
-K2PgTransactionsEnabled()
+bool K2PgTransactionsEnabled()
 {
 	static int cached_value = -1;
 	if (cached_value == -1)
@@ -163,8 +155,7 @@ K2PgTransactionsEnabled()
 	return IsK2PgEnabled() && cached_value;
 }
 
-void
-K2PgReportFeatureUnsupported(const char *msg)
+void K2PgReportFeatureUnsupported(const char *msg)
 {
 	ereport(ERROR,
 			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -172,8 +163,7 @@ K2PgReportFeatureUnsupported(const char *msg)
 }
 
 
-static bool
-K2PgShouldReportErrorStatus()
+static bool K2PgShouldReportErrorStatus()
 {
 	static int cached_value = -1;
 	if (cached_value == -1)
@@ -184,8 +174,7 @@ K2PgShouldReportErrorStatus()
 	return cached_value;
 }
 
-void
-HandleK2PgStatus(const K2PgStatus& status)
+void HandleK2PgStatus(const K2PgStatus& status)
 {
     if (status.pg_code == ERRCODE_SUCCESSFUL_COMPLETION) {
         return;
@@ -196,8 +185,7 @@ HandleK2PgStatus(const K2PgStatus& status)
     ereport(ERROR, (errcode(status.pg_code), errmsg("Status: %s: %s", status.msg.c_str(), status.detail.c_str())));
 }
 
-void
-HandleK2PgStatusIgnoreNotFound(const K2PgStatus& status, bool *not_found)
+void HandleK2PgStatusIgnoreNotFound(const K2PgStatus& status, bool *not_found)
 {
 	if (status.k2_code == 404) {
 		*not_found = true;
@@ -207,8 +195,7 @@ HandleK2PgStatusIgnoreNotFound(const K2PgStatus& status, bool *not_found)
 	HandleK2PgStatus(status);
 }
 
-void
-HandleK2PgTableDescStatus(const K2PgStatus& status, K2PgTableDesc table)
+void HandleK2PgTableDescStatus(const K2PgStatus& status, K2PgTableDesc table)
 {
 	HandleK2PgStatus(status);
 }
@@ -218,8 +205,7 @@ HandleK2PgTableDescStatus(const K2PgStatus& status, K2PgTableDesc table)
  * If relation is not an index and it has primary key the name of primary key index is returned.
  * In other cases, relation name is used.
  */
-static void
-FetchUniqueConstraintName(Oid relation_id, char* dest, size_t max_size)
+static void FetchUniqueConstraintName(Oid relation_id, char* dest, size_t max_size)
 {
 	// strncat appends source to destination, so destination must be empty.
 	dest[0] = 0;
@@ -274,20 +260,17 @@ void K2PgInitSession(const char *db_name) {
 	}
 }
 
-void
-K2PgOnPostgresBackendShutdown()
+void K2PgOnPostgresBackendShutdown()
 {
 	PgGate_DestroyPgGate();
 }
 
 static bool k2pg_preparing_templates = false;
-void
-K2PgSetPreparingTemplates() {
+void K2PgSetPreparingTemplates() {
 	k2pg_preparing_templates = true;
 }
 
-bool
-K2PgIsPreparingTemplates() {
+bool K2PgIsPreparingTemplates() {
 	return k2pg_preparing_templates;
 }
 
@@ -458,8 +441,7 @@ K2PgHeapTupleToString(HeapTuple tuple, TupleDesc tupleDesc)
 	return buf.data;
 }
 
-bool
-K2PgIsInitDbAlreadyDone()
+bool K2PgIsInitDbAlreadyDone()
 {
 	bool done = false;
 	HandleK2PgStatus(PgGate_IsInitDbDone(&done));
@@ -586,14 +568,17 @@ static bool IsTransactionalDdlStatement(NodeTag node_tag) {
 	}
 }
 
-bool
-K2PgIsEnvVarTrue(const char* env_var_name)
+bool IsK2PgLocalNodeInitdbMode()
+{
+	return K2PgIsEnvVarTrue("K2PG_LOCAL_NODE_INITDB");
+}
+
+bool K2PgIsEnvVarTrue(const char* env_var_name)
 {
 	return K2PgIsEnvVarTrueWithDefault(env_var_name, /* default_value */ false);
 }
 
-bool
-K2PgIsEnvVarTrueWithDefault(const char* env_var_name, bool default_value)
+bool K2PgIsEnvVarTrueWithDefault(const char* env_var_name, bool default_value)
 {
 	const char* env_var_value = getenv(env_var_name);
 	if (!env_var_value ||
@@ -605,8 +590,7 @@ K2PgIsEnvVarTrueWithDefault(const char* env_var_name, bool default_value)
 	return strcmp(env_var_value, "1") == 0 || strcmp(env_var_value, "true") == 0;
 }
 
-bool
-K2PgIsEnabledInPostgresEnvVar()
+bool K2PgIsEnabledInPostgresEnvVar()
 {
 	static int cached_value = -1;
 	if (cached_value == -1)

--- a/src/include/access/k2/k2pg_aux.h
+++ b/src/include/access/k2/k2pg_aux.h
@@ -224,6 +224,8 @@ void K2PgDecrementDdlNestingLevel(bool success);
 
 #define K2PG_INITDB_ALREADY_DONE_EXIT_CODE 125
 
+extern bool IsK2PgLocalNodeInitdbMode();
+
 /**
  * Checks if the given environment variable is set to a "true" value (e.g. "1").
  */


### PR DESCRIPTION
add local initdb to not bootstrap template dbs but create configuration files only

commit 819eb3c36e36e3c0c2d9462e6926973966f40a8d (HEAD -> mainline-local-initdb, origin/mainline-local-initdb)
Author: Ahsan Khan <ahsankhanmail@gmail.com>
Date:   Thu Dec 15 15:53:08 2022 -0800

    Increase timeout of two phase commit worker (#116)
    
    Co-authored-by: Ahsan Khan <akhan@futurewei.com>

commit 3b69ea46fead364026cdab6f603f22933e5ea5a2
Author: johnfangAFW <jfang@futurewei.com>
Date:   Tue Dec 13 15:56:27 2022 -0800

    add init local mode for initdb to avoid recreating template databases