### PR TITLE
copy skeys in camBeginScan to avoid the original object goes out of scope

### DIFF
--- a/src/gausskernel/storage/access/k2/k2catam.cpp
+++ b/src/gausskernel/storage/access/k2/k2catam.cpp
@@ -980,7 +980,11 @@ CamScanDesc camBeginScan(Relation relation, Relation index, bool xs_want_itup, i
 
 	/* Set up K2PG scan description */
 	CamScanDesc camScan = (CamScanDesc) palloc0(sizeof(CamScanDescData));
-	camScan->key   = key;
+	// copy the keys to avoid the current keys go out of scope for subsequent scan operations
+	size_t size = sizeof(ScanKeyData) * nkeys;
+	ScanKeyData *s_keys = (ScanKeyData *)palloc0(size);
+	memcpy(s_keys, key, size);
+	camScan->key = s_keys;
 	camScan->nkeys = nkeys;
 	camScan->tableOid = RelationGetRelid(relation);
 


### PR DESCRIPTION
Fix the issue that the sk_flag became garbage during scan process since the skey object was out of scope.
Use palloc0 to allocate memory from the current memory context so that it would be clean up automatically when query finishes.